### PR TITLE
Integrate Movies and TV Series into the Kodi library

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,35 @@ De volgende features worden ondersteund:
 * Afspelen van films en series
 * Volledig overzicht van alle content
 * Zoeken in de volledige catalogus
+* Integratie met Kodi bibliotheek
+
+## Integratie met Kodi
+
+Je kan deze Add-on gebruiken als medialocatie in Kodi zodat de films en series ook in je Kodi bibliotheek geindexeerd staan. Ze worden uiteraard nog steeds
+gewoon gestreamed.
+
+Ga hiervoor naar **Instellingen** > **Media** > **Bibliotheek** > **Video's...** (bij bronnen beheren). Kies vervolgens **Toevoegen video's...** en geef
+onderstaande locatie in door **< Geen >** te kiezen. Geef vervolgens de naam op en kies OK. Stel daarna de opties in zoals hieronder opgegeven en bevestig met OK.
+Stem daarna toe om deze locaties te scannen.
+
+* Films:
+  * Locatie: `plugin://plugin.video.streamz/library/movies/`
+  * Naam: **Streamz - Films**
+  * Opties:
+    * Deze map bevat: **Speelfilms**
+    * Kies informatieleverancier: **Local information only**
+    * Films staan in aparte folders die overeenkomen met de filmtitel: **Uit**
+    * Ook onderliggende mappen scannen : **Uit**
+    * Locatie uitsluiten van bibliotheekupdates: **Uit**
+
+* Series:
+  * Locatie: `plugin://plugin.video.streamz/library/tvshows/`
+  * Naam: **Streamz - Series**
+  * Opties:
+    * Deze map bevat: **Series**
+    * Kies informatieleverancier: **Local information only**
+    * Geselecteerde map bevat één enkele serie: **Uit**
+    * Locatie uitsluiten van bibliotheekupdates: **Uit**
 
 ## Screenshots
 

--- a/addon.xml
+++ b/addon.xml
@@ -12,6 +12,8 @@
     </requires>
     <extension point="xbmc.python.pluginsource" library="addon_entry.py">
         <provides>video</provides>
+        <medialibraryscanpath content="movies">library/movies/</medialibraryscanpath>
+        <medialibraryscanpath content="tvshows">library/tvshows/</medialibraryscanpath>
     </extension>
     <extension point="xbmc.service" library="service_entry.py"/>
     <extension point="xbmc.addon.metadata">

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -185,7 +185,6 @@ msgctxt "#30716"
 msgid "Updating metadata ({index}/{total})..."
 msgstr ""
 
-
 ### SETTINGS
 msgctxt "#30800"
 msgid "Credentials"
@@ -301,6 +300,46 @@ msgstr ""
 
 msgctxt "#30864"
 msgid "Up Next settings…"
+msgstr ""
+
+msgctxt "#30870"
+msgid "Kodi Library"
+msgstr ""
+
+msgctxt "#30871"
+msgid "Indexing"
+msgstr ""
+
+msgctxt "#30872"
+msgid "Add video locations to the Kodi Library… [COLOR gray](See README.md)[/COLOR]"
+msgstr ""
+
+msgctxt "#30873"
+msgid "Index the following movies"
+msgstr ""
+
+msgctxt "#30874"
+msgid "Index the following series"
+msgstr ""
+
+msgctxt "#30875"
+msgid "Full catalog"
+msgstr ""
+
+msgctxt "#30876"
+msgid "Items on 'My List' only"
+msgstr ""
+
+msgctxt "#30877"
+msgid "Maintenance"
+msgstr ""
+
+msgctxt "#30878"
+msgid "Refresh Library…"
+msgstr ""
+
+msgctxt "#30879"
+msgid "Clean Library…"
 msgstr ""
 
 msgctxt "#30880"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -304,6 +304,46 @@ msgctxt "#30864"
 msgid "Up Next settings…"
 msgstr "Up Next instellingen…"
 
+msgctxt "#30870"
+msgid "Kodi Library"
+msgstr "Kodi-bibliotheek"
+
+msgctxt "#30871"
+msgid "Indexing"
+msgstr "Indexeren"
+
+msgctxt "#30872"
+msgid "Add video locations to the Kodi Library… [COLOR gray](See README.md)[/COLOR]"
+msgstr "Videolocaties toevoegen aan de Kodi-bibliotheek… [COLOR gray](Zie README.md)[/COLOR]"
+
+msgctxt "#30873"
+msgid "Index the following movies"
+msgstr "Indexeer de volgende films"
+
+msgctxt "#30874"
+msgid "Index the following series"
+msgstr "Indexeer de volgende series"
+
+msgctxt "#30875"
+msgid "Full catalog"
+msgstr "Volledige catalogus"
+
+msgctxt "#30876"
+msgid "Items on 'My List' only"
+msgstr "Enkel items op 'Mijn lijst'"
+
+msgctxt "#30877"
+msgid "Maintenance"
+msgstr "Onderhoud"
+
+msgctxt "#30878"
+msgid "Refresh Library…"
+msgstr "Verniew bibliotheek…"
+
+msgctxt "#30879"
+msgid "Clean Library…"
+msgstr "Bibliotheek opkuisen…"
+
 msgctxt "#30880"
 msgid "Expert"
 msgstr "Expert"

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -8,8 +8,6 @@ import logging
 import routing
 
 from resources.lib import kodilogging, kodiutils
-from resources.lib.streamz.exceptions import (NoLoginException, InvalidLoginException, LoginErrorException, NoTelenetSubscriptionException,
-                                              NoStreamzSubscriptionException)
 
 kodilogging.config()
 routing = routing.Plugin()  # pylint: disable=invalid-name

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -8,6 +8,8 @@ import logging
 import routing
 
 from resources.lib import kodilogging, kodiutils
+from resources.lib.streamz.exceptions import (NoLoginException, InvalidLoginException, LoginErrorException, NoTelenetSubscriptionException,
+                                              NoStreamzSubscriptionException)
 
 kodilogging.config()
 routing = routing.Plugin()  # pylint: disable=invalid-name
@@ -78,6 +80,66 @@ def show_catalog_program_season(program, season):
     """ Show a program from the catalog """
     from resources.lib.modules.catalog import Catalog
     Catalog().show_program_season(program, int(season))
+
+
+@routing.route('/library/movies/')
+def library_movies():
+    """ Show a list of all movies for integration into the Kodi Library """
+    from resources.lib.modules.library import Library
+
+    # Library seems to have issues with folder mode
+    movie = routing.args.get('movie', [])[0] if routing.args.get('movie') else None
+
+    if 'check_exists' in routing.args.get('kodi_action', []):
+        Library().check_library_movie(movie)
+        return
+
+    if movie:
+        play('movies', movie)
+    else:
+        Library().show_library_movies()
+
+
+@routing.route('/library/tvshows/')
+def library_tvshows():
+    """ Show a list of all tv series for integration into the Kodi Library """
+    from resources.lib.modules.library import Library
+
+    # Library seems to have issues with folder mode
+    program = routing.args.get('program', [])[0] if routing.args.get('program') else None
+    episode = routing.args.get('episode', [])[0] if routing.args.get('episode') else None
+
+    if 'check_exists' in routing.args.get('kodi_action', []):
+        Library().check_library_tvshow(program)
+        return
+
+    if episode:
+        play('episodes', episode)
+    elif program:
+        Library().show_library_tvshows_program(program)
+    else:
+        Library().show_library_tvshows()
+
+
+@routing.route('/library/configure')
+def library_configure():
+    """ Show information on how to enable the library integration """
+    from resources.lib.modules.library import Library
+    Library().configure()
+
+
+@routing.route('/library/update')
+def library_update():
+    """ Refresh the library. """
+    from resources.lib.modules.library import Library
+    Library().update()
+
+
+@routing.route('/library/clean')
+def library_clean():
+    """ Clean the library. """
+    from resources.lib.modules.library import Library
+    Library().clean()
 
 
 @routing.route('/catalog/recommendations/<storefront>')

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -94,6 +94,10 @@ def library_movies():
         Library().check_library_movie(movie)
         return
 
+    if 'refresh_info' in routing.args.get('kodi_action', []):
+        Library().show_library_movies(movie)
+        return
+
     if movie:
         play('movies', movie)
     else:
@@ -111,6 +115,10 @@ def library_tvshows():
 
     if 'check_exists' in routing.args.get('kodi_action', []):
         Library().check_library_tvshow(program)
+        return
+
+    if 'refresh_info' in routing.args.get('kodi_action', []):
+        Library().show_library_tvshows(program)
         return
 
     if episode:
@@ -169,12 +177,18 @@ def mylist_add(video_type, content_id):
     from resources.lib.modules.catalog import Catalog
     Catalog().mylist_add(video_type, content_id)
 
+    from resources.lib.modules.library import Library
+    Library().mylist_added(video_type, content_id)
+
 
 @routing.route('/catalog/mylist/del/<video_type>/<content_id>')
 def mylist_del(video_type, content_id):
     """ Remove an item from "My List" """
     from resources.lib.modules.catalog import Catalog
     Catalog().mylist_del(video_type, content_id)
+
+    from resources.lib.modules.library import Library
+    Library().mylist_removed(video_type, content_id)
 
 
 @routing.route('/catalog/continuewatching')

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -637,21 +637,6 @@ def invalidate_cache(ttl=None):
         xbmcvfs.delete(filepath)
 
 
-def cleanup_cache(category, keep):
-    """ Clear the cache by removing missing items. """
-    fullpath = get_cache_path() + '/'
-
-    if not xbmcvfs.exists(fullpath):
-        return
-
-    _, files = xbmcvfs.listdir(fullpath)
-    for filename in files:
-        cat, uuid = filename.split('.')
-        if cat == category and uuid not in keep:
-            _LOGGER.debug('Removing %s from cache since it is missing in the full listing', filename)
-            xbmcvfs.delete(os.path.join(fullpath, filename))
-
-
 def notify(sender, message, data):
     """ Send a notification to Kodi using JSON RPC """
     result = jsonrpc(method='JSONRPC.NotifyAll', params=dict(

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -599,7 +599,7 @@ def get_cache(key, ttl=None):
 def set_cache(key, data):
     """ Store an item in the cache
     :type key: list[str]
-    :type data: str|None
+    :type data: any
     """
     fullpath = get_cache_path() + '/'
     if not xbmcvfs.exists(fullpath):

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -224,6 +224,14 @@ def play(stream, license_key=None, title=None, art_dict=None, info_dict=None, pr
     xbmcplugin.setResolvedUrl(routing.handle, True, listitem=play_item)
 
 
+def library_return_status(success):
+    """Notify Kodi about the status of a listitem."""
+    from resources.lib.addon import routing
+
+    _LOGGER.debug('Returning status %s', success)
+    xbmcplugin.setResolvedUrl(routing.handle, success, listitem=xbmcgui.ListItem())
+
+
 def get_search_string(heading='', message=''):
     """Ask the user for a search string"""
     search_string = None
@@ -243,6 +251,14 @@ def ok_dialog(heading='', message=''):
         # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
         return Dialog().ok(heading=heading, line1=message)
     return Dialog().ok(heading=heading, message=message)
+
+
+def textviewer(heading='', text='', usemono=False):
+    """Show Kodi's textviewer dialog"""
+    from xbmcgui import Dialog
+    if not heading:
+        heading = addon_name()
+    Dialog().textviewer(heading=heading, text=text, usemono=usemono)
 
 
 def show_context_menu(items):
@@ -562,7 +578,6 @@ def get_cache(key, ttl=None):
     import time
 
     fullpath = os.path.join(get_cache_path(), '.'.join(key))
-
     if not xbmcvfs.exists(fullpath):
         return None
 
@@ -584,12 +599,18 @@ def get_cache(key, ttl=None):
 def set_cache(key, data):
     """ Store an item in the cache
     :type key: list[str]
-    :type data: str
+    :type data: str|None
     """
-    if not xbmcvfs.exists(get_cache_path()):
-        xbmcvfs.mkdirs(get_cache_path())
+    fullpath = get_cache_path() + '/'
+    if not xbmcvfs.exists(fullpath):
+        xbmcvfs.mkdirs(fullpath)
 
-    fullpath = os.path.join(get_cache_path(), '.'.join(key))
+    fullpath = os.path.join(fullpath, '.'.join(key))
+
+    if data is None:
+        # Remove from cache
+        xbmcvfs.delete(fullpath)
+        return
 
     fdesc = xbmcvfs.File(fullpath, 'w')
 
@@ -602,8 +623,7 @@ def set_cache(key, data):
 
 def invalidate_cache(ttl=None):
     """ Clear the cache """
-    fullpath = get_cache_path()
-
+    fullpath = get_cache_path() + '/'
     if not xbmcvfs.exists(fullpath):
         return
 
@@ -615,6 +635,21 @@ def invalidate_cache(ttl=None):
         if ttl and now - xbmcvfs.Stat(filepath).st_mtime() < ttl:
             continue
         xbmcvfs.delete(filepath)
+
+
+def cleanup_cache(category, keep):
+    """ Clear the cache by removing missing items. """
+    fullpath = get_cache_path() + '/'
+
+    if not xbmcvfs.exists(fullpath):
+        return
+
+    _, files = xbmcvfs.listdir(fullpath)
+    for filename in files:
+        cat, uuid = filename.split('.')
+        if cat == category and uuid not in keep:
+            _LOGGER.debug('Removing %s from cache since it is missing in the full listing', filename)
+            xbmcvfs.delete(os.path.join(fullpath, filename))
 
 
 def notify(sender, message, data):

--- a/resources/lib/modules/catalog.py
+++ b/resources/lib/modules/catalog.py
@@ -184,7 +184,7 @@ class Catalog:
                 listing.append(Menu.generate_titleitem(item))
 
         # Sort categories by default like in Streamz.
-        kodiutils.show_listing(listing, 30015, content='tvshows')
+        kodiutils.show_listing(listing, 30015, content='tvshows', sort=['unsorted', 'label', 'year', 'duration'])
 
     def show_mylist(self):
         """ Show the items in "My List". """
@@ -196,7 +196,7 @@ class Catalog:
             listing.append(Menu.generate_titleitem(item))
 
         # Sort categories by default like in Streamz.
-        kodiutils.show_listing(listing, 30017, content='tvshows')
+        kodiutils.show_listing(listing, 30017, content='tvshows', sort=['unsorted', 'label', 'year', 'duration'])
 
     def mylist_add(self, video_type, content_id):
         """ Add an item to "My List".

--- a/resources/lib/modules/catalog.py
+++ b/resources/lib/modules/catalog.py
@@ -215,7 +215,6 @@ class Catalog:
         """
         self._api.del_mylist(video_type, content_id)
         kodiutils.end_of_directory()
-        kodiutils.container_refresh()
 
     def show_continuewatching(self):
         """ Show the items in "Continue Watching". """

--- a/resources/lib/modules/library.py
+++ b/resources/lib/modules/library.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+""" Library module """
+
+from __future__ import absolute_import, division, unicode_literals
+
+import logging
+
+from resources.lib import kodiutils
+from resources.lib.modules.menu import Menu
+from resources.lib.streamz import Movie, Program
+from resources.lib.streamz.api import Api, CACHE_PREVENT, CACHE_AUTO
+from resources.lib.streamz.auth import Auth
+from resources.lib.streamz.exceptions import UnavailableException
+
+_LOGGER = logging.getLogger(__name__)
+
+LIBRARY_FULL_CATALOG = 0
+LIBRARY_ONLY_MYLIST = 1
+
+
+class Library:
+    """ Menu code related to the catalog """
+
+    def __init__(self):
+        """ Initialise object """
+        self._auth = Auth(kodiutils.get_setting('username'),
+                          kodiutils.get_setting('password'),
+                          kodiutils.get_setting('loginprovider'),
+                          kodiutils.get_setting('profile'),
+                          kodiutils.get_tokens_path())
+        self._api = Api(self._auth)
+
+    def show_library_movies(self):
+        """ Return a list of the movies that should be exported. """
+        if kodiutils.get_setting_int('library_movies') == LIBRARY_FULL_CATALOG:
+            # Full catalog
+            # Use cache if available, fetch from api otherwise so we get rich metadata for new content
+            items = self._api.get_items(content_filter=Movie, cache=CACHE_AUTO)
+
+            # Remove old caches
+            # When Kodi does a clean of the library, we validate a movie by its presence in the cache, so we need to make sure that
+            # items that aren't available anymore are also removed from the cache
+            kodiutils.cleanup_cache('movie', [item.movie_id for item in items])
+        else:
+            # Only favourites, use cache if available, fetch from api otherwise
+            items = self._api.get_swimlane('my-list', content_filter=Movie)
+
+        listing = []
+        for item in items:
+            title_item = Menu.generate_titleitem(item)
+            # title_item.path = kodiutils.url_for('library_movies', movie=item.movie_id)
+            title_item.path = 'plugin://plugin.video.streamz/library/movies/?movie=%s' % item.movie_id
+            listing.append(title_item)
+
+        kodiutils.show_listing(listing, 30003, content='movies', sort=['label', 'year', 'duration'])
+
+    def show_library_tvshows(self):
+        """ Return a list of the series that should be exported. """
+        if kodiutils.get_setting_int('library_tvshows') == LIBRARY_FULL_CATALOG:
+            # Full catalog
+            # Use cache if available, fetch from api otherwise so we get rich metadata for new content
+            # NOTE: We should probably use CACHE_PREVENT here, so we can pick up new episodes, but we can't since that would
+            #       require a massive amount of API calls for each update. We do this only for programs in 'My list'.
+            items = self._api.get_items(content_filter=Program, cache=CACHE_AUTO)
+
+            # Remove old caches
+            # When Kodi does a clean of the library, we validate a tvshow by its presence in the cache, so we need to make sure that
+            # items that aren't available anymore are also removed from the cache
+            kodiutils.cleanup_cache('program', [item.program_id for item in items])
+        else:
+            # Only favourites, don't use cache, fetch from api
+            # If we use CACHE_AUTO, we will miss updates until the user manually opens the program in the Add-on
+            items = self._api.get_swimlane('my-list', content_filter=Program, cache=CACHE_PREVENT)
+
+        listing = []
+        for item in items:
+            title_item = Menu.generate_titleitem(item)
+            # title_item.path = kodiutils.url_for('library_tvshows', program=item.program_id) + '/'  # Folders need a trailing slash
+            title_item.path = 'plugin://plugin.video.streamz/library/tvshows/?program={program_id}'.format(program_id=item.program_id)
+            listing.append(title_item)
+
+        kodiutils.show_listing(listing, 30003, content='tvshows', sort=['label', 'year', 'duration'])
+
+    def show_library_tvshows_program(self, program):
+        """ Return a list of the episodes that should be exported. """
+        program_obj = self._api.get_program(program)
+
+        listing = []
+        for season in list(program_obj.seasons.values()):
+            for item in list(season.episodes.values()):
+                title_item = Menu.generate_titleitem(item)
+                # title_item.path = kodiutils.url_for('library_tvshows', program=item.program_id, episode=item.episode_id)
+                title_item.path = 'plugin://plugin.video.streamz/library/tvshows/?program={program_id}&episode={episode_id}'.format(program_id=item.program_id,
+                                                                                                                                    episode_id=item.episode_id)
+                listing.append(title_item)
+
+        # Sort by episode number by default. Takes seasons into account.
+        kodiutils.show_listing(listing, 30003, content='episodes', sort=['episode', 'duration'])
+
+    def check_library_movie(self, movie):
+        """ Check if the given movie is still available. """
+        _LOGGER.debug('Checking if movie %s is still available', movie)
+
+        # Our parent path always exists
+        if movie is None:
+            kodiutils.library_return_status(True)
+            return
+
+        if kodiutils.get_setting_int('library_movies') == LIBRARY_FULL_CATALOG:
+            # Full library
+            try:
+                result = self._api.get_movie(movie)
+            except UnavailableException:
+                result = None
+            kodiutils.library_return_status(result is not None)
+
+        else:
+            # Only favourites
+            mylist_ids = self._api.get_swimlane_ids('my-list')
+            kodiutils.library_return_status(movie in mylist_ids)
+
+    def check_library_tvshow(self, program):
+        """ Check if the given program is still available. """
+        _LOGGER.debug('Checking if program %s is still available', program)
+
+        # Our parent path always exists
+        if program is None:
+            kodiutils.library_return_status(True)
+            return
+
+        if kodiutils.get_setting_int('library_tvshows') == LIBRARY_FULL_CATALOG:
+            # Full catalog
+            try:
+                result = self._api.get_program(program, cache=CACHE_PREVENT)
+            except UnavailableException:
+                result = None
+            kodiutils.library_return_status(result is not None)
+
+        else:
+            # Only favourites
+            mylist_ids = self._api.get_swimlane_ids('my-list')
+            kodiutils.library_return_status(program in mylist_ids)
+
+    @staticmethod
+    def configure():
+        """ Configure the library integration. """
+        # There seems to be no way to add sources automatically.
+        # * https://forum.kodi.tv/showthread.php?tid=228840
+
+        # Open the sources view
+        kodiutils.execute_builtin('ActivateWindow(Videos,sources://video/)')
+
+    @staticmethod
+    def update():
+        """ Update the library integration. """
+        kodiutils.jsonrpc(method='VideoLibrary.Scan')
+
+    @staticmethod
+    def clean():
+        """ Cleanup the library integration. """
+        kodiutils.jsonrpc(method='VideoLibrary.Clean')

--- a/resources/lib/modules/library.py
+++ b/resources/lib/modules/library.py
@@ -36,11 +36,6 @@ class Library:
                 # Full catalog
                 # Use cache if available, fetch from api otherwise so we get rich metadata for new content
                 items = self._api.get_items(content_filter=Movie, cache=CACHE_AUTO)
-
-                # Remove old caches
-                # When Kodi does a clean of the library, we validate a movie by its presence in the cache, so we need to make sure that
-                # items that aren't available anymore are also removed from the cache
-                kodiutils.cleanup_cache('movie', [item.movie_id for item in items])
             else:
                 # Only favourites, use cache if available, fetch from api otherwise
                 items = self._api.get_swimlane('my-list', content_filter=Movie)
@@ -50,7 +45,7 @@ class Library:
         listing = []
         for item in items:
             title_item = Menu.generate_titleitem(item)
-            # title_item.path = kodiutils.url_for('library_movies', movie=item.movie_id)
+            # title_item.path = kodiutils.url_for('library_movies', movie=item.movie_id)  # We need a trailing /
             title_item.path = 'plugin://plugin.video.streamz/library/movies/?movie=%s' % item.movie_id
             listing.append(title_item)
 
@@ -65,11 +60,6 @@ class Library:
                 # NOTE: We should probably use CACHE_PREVENT here, so we can pick up new episodes, but we can't since that would
                 #       require a massive amount of API calls for each update. We do this only for programs in 'My list'.
                 items = self._api.get_items(content_filter=Program, cache=CACHE_AUTO)
-
-                # Remove old caches
-                # When Kodi does a clean of the library, we validate a tvshow by its presence in the cache, so we need to make sure that
-                # items that aren't available anymore are also removed from the cache
-                kodiutils.cleanup_cache('program', [item.program_id for item in items])
             else:
                 # Only favourites, don't use cache, fetch from api
                 # If we use CACHE_AUTO, we will miss updates until the user manually opens the program in the Add-on
@@ -81,7 +71,7 @@ class Library:
         listing = []
         for item in items:
             title_item = Menu.generate_titleitem(item)
-            # title_item.path = kodiutils.url_for('library_tvshows', program=item.program_id) + '/'  # Folders need a trailing slash
+            # title_item.path = kodiutils.url_for('library_tvshows', program=item.program_id)  # We need a trailing /
             title_item.path = 'plugin://plugin.video.streamz/library/tvshows/?program={program_id}'.format(program_id=item.program_id)
             listing.append(title_item)
 

--- a/resources/lib/modules/library.py
+++ b/resources/lib/modules/library.py
@@ -10,7 +10,6 @@ from resources.lib.modules.menu import Menu
 from resources.lib.streamz import Movie, Program
 from resources.lib.streamz.api import CACHE_AUTO, CACHE_PREVENT, CONTENT_TYPE_MOVIE, CONTENT_TYPE_PROGRAM, Api
 from resources.lib.streamz.auth import Auth
-from resources.lib.streamz.exceptions import UnavailableException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -114,15 +113,11 @@ class Library:
             return
 
         if kodiutils.get_setting_int('library_movies') == LIBRARY_FULL_CATALOG:
-            try:
-                result = self._api.get_movie(movie, cache=CACHE_AUTO)
-            except UnavailableException:
-                result = None
-            kodiutils.library_return_status(result is not None)
-
+            id_list = self._api.get_catalog_ids()
         else:
-            mylist_ids = self._api.get_swimlane_ids('my-list')
-            kodiutils.library_return_status(movie in mylist_ids)
+            id_list = self._api.get_mylist_ids()
+
+        kodiutils.library_return_status(movie in id_list)
 
     def check_library_tvshow(self, program):
         """ Check if the given program is still available. """
@@ -134,15 +129,11 @@ class Library:
             return
 
         if kodiutils.get_setting_int('library_tvshows') == LIBRARY_FULL_CATALOG:
-            try:
-                result = self._api.get_program(program, cache=CACHE_AUTO)
-            except UnavailableException:
-                result = None
-            kodiutils.library_return_status(result is not None)
-
+            id_list = self._api.get_catalog_ids()
         else:
-            mylist_ids = self._api.get_swimlane_ids('my-list')
-            kodiutils.library_return_status(program in mylist_ids)
+            id_list = self._api.get_mylist_ids()
+
+        kodiutils.library_return_status(program in id_list)
 
     @staticmethod
     def mylist_added(video_type, content_id):

--- a/resources/lib/modules/library.py
+++ b/resources/lib/modules/library.py
@@ -115,7 +115,7 @@ class Library:
 
         if kodiutils.get_setting_int('library_movies') == LIBRARY_FULL_CATALOG:
             try:
-                result = self._api.get_movie(movie)
+                result = self._api.get_movie(movie, cache=CACHE_AUTO)
             except UnavailableException:
                 result = None
             kodiutils.library_return_status(result is not None)
@@ -135,7 +135,7 @@ class Library:
 
         if kodiutils.get_setting_int('library_tvshows') == LIBRARY_FULL_CATALOG:
             try:
-                result = self._api.get_program(program, cache=CACHE_PREVENT)
+                result = self._api.get_program(program, cache=CACHE_AUTO)
             except UnavailableException:
                 result = None
             kodiutils.library_return_status(result is not None)

--- a/resources/lib/modules/library.py
+++ b/resources/lib/modules/library.py
@@ -8,7 +8,7 @@ import logging
 from resources.lib import kodiutils
 from resources.lib.modules.menu import Menu
 from resources.lib.streamz import Movie, Program
-from resources.lib.streamz.api import Api, CACHE_PREVENT, CACHE_AUTO, CONTENT_TYPE_MOVIE, CONTENT_TYPE_PROGRAM
+from resources.lib.streamz.api import CACHE_AUTO, CACHE_PREVENT, CONTENT_TYPE_MOVIE, CONTENT_TYPE_PROGRAM, Api
 from resources.lib.streamz.auth import Auth
 from resources.lib.streamz.exceptions import UnavailableException
 

--- a/resources/lib/modules/menu.py
+++ b/resources/lib/modules/menu.py
@@ -253,6 +253,7 @@ class Menu:
                 art_dict=art_dict,
                 info_dict=info_dict,
                 stream_dict=stream_dict,
+                prop_dict=prop_dict,
                 context_menu=context_menu,
                 is_playable=True,
             )
@@ -278,8 +279,11 @@ class Menu:
                 'fanart': item.image,
             })
             info_dict.update({
-                'mediatype': None,
+                'mediatype': 'tvshow',
                 'season': len(item.seasons),
+            })
+            prop_dict.update({
+                'hash': item.content_hash,
             })
 
             return TitleItem(
@@ -287,6 +291,7 @@ class Menu:
                 path=kodiutils.url_for('show_catalog_program', program=item.program_id),
                 art_dict=art_dict,
                 info_dict=info_dict,
+                prop_dict=prop_dict,
                 context_menu=context_menu,
             )
 

--- a/resources/lib/modules/metadata.py
+++ b/resources/lib/modules/metadata.py
@@ -45,7 +45,7 @@ class Metadata:
 
         :type callback: callable
         """
-        # Fetch all items from the catalog
+        # Fetch a list of all items from the catalog
         items = self._api.get_items()
         count = len(items)
 

--- a/resources/lib/streamz/__init__.py
+++ b/resources/lib/streamz/__init__.py
@@ -97,7 +97,7 @@ class Program:
     """ Defines a Program """
 
     def __init__(self, program_id=None, name=None, description=None, cover=None, image=None, seasons=None,
-                 geoblocked=None, channel=None, legal=None, my_list=None):
+                 geoblocked=None, channel=None, legal=None, my_list=None, content_hash=None):
         """
         :type program_id: str
         :type name: str
@@ -109,6 +109,7 @@ class Program:
         :type channel: str
         :type legal: str
         :type my_list: bool
+        :type content_hash: str
         """
         self.program_id = program_id
         self.name = name
@@ -120,6 +121,7 @@ class Program:
         self.channel = channel
         self.legal = legal
         self.my_list = my_list
+        self.content_hash = content_hash
 
     def __repr__(self):
         return "%r" % self.__dict__

--- a/resources/lib/streamz/api.py
+++ b/resources/lib/streamz/api.py
@@ -116,10 +116,7 @@ class Api:
                                      profile=self._tokens.profile)
 
             # Result can be empty
-            if not response.text:
-                return []
-
-            result = json.loads(response.text)
+            result = json.loads(response.text) if response.text else []
 
             kodiutils.set_cache(['swimlane', swimlane], result)
 

--- a/resources/lib/streamz/api.py
+++ b/resources/lib/streamz/api.py
@@ -114,6 +114,11 @@ class Api:
             response = util.http_get(API_ENDPOINT + '/%s/main/swimlane/%s' % (self._mode(), swimlane),
                                      token=self._tokens.jwt_token,
                                      profile=self._tokens.profile)
+
+            # Result can be empty
+            if not response.text:
+                return []
+
             result = json.loads(response.text)
 
             kodiutils.set_cache(['swimlane', swimlane], result)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -27,6 +27,15 @@
 <!--        <setting label="30843" type="lsep"/> &lt;!&ndash; Streaming &ndash;&gt;-->
 <!--        <setting label="30844" type="select" id="max_bandwidth" default="0" values="0|256|512|1024|1536|2048|2560|3072|4096|6144|8192|10240|15360|20480|25600|30720"/>-->
 <!--    </category>-->
+    <category label="30870"> <!-- Kodi Library -->
+        <setting label="30871" type="lsep"/> <!-- Indexing -->
+        <setting label="30872" type="action" action="RunPlugin(plugin://plugin.video.streamz/library/configure)" option="close"/>
+        <setting label="30873" type="select" id="library_movies" default="1" lvalues="30875|30876"/>
+        <setting label="30874" type="select" id="library_tvshows" default="1" lvalues="30875|30876"/>
+        <setting label="30877" type="lsep"/> <!-- Maintenance -->
+        <setting label="30878" type="action" action="RunPlugin(plugin://plugin.video.streamz/library/update)"/>
+        <setting label="30879" type="action" action="RunPlugin(plugin://plugin.video.streamz/library/clean)"/>
+    </category>
     <category label="30860"> <!-- Integrations -->
         <setting label="30861" type="lsep"/> <!-- Up Next -->
         <setting label="30862" type="action" action="InstallAddon(service.upnext)" option="close" visible="!System.HasAddon(service.upnext)"/>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -56,6 +56,14 @@ class TestApi(unittest.TestCase):
         results = self.api.do_search('huis')
         self.assertIsInstance(results, list)
 
+    def test_mylist_ids(self):
+        mylist = self.api.get_mylist_ids()
+        self.assertIsInstance(mylist, list)
+
+    def test_catalog_ids(self):
+        mylist = self.api.get_catalog_ids()
+        self.assertIsInstance(mylist, list)
+
     def test_errors(self):
         with self.assertRaises(UnavailableException):
             self.api.get_movie('0')


### PR DESCRIPTION
Allows to integrate the movies and tv series into Kodi. You have the option to configure the behaviour to export everything or only the items in "My List". This can be configured separately for movies and series. When switching from a full export to "My List", you need to run Library cleanup for the other items to be removed from your library.

When running a library cleanup, we take a snapshot of all ids's in the catalog (or in my list if you only export that) and check if they are in that list. This is a lot faster than using the API, and is also more correct compared with if we would use the cache.

There were quite some issues / wtf's:
* I couldn't get the Library cleanup feature to work reliably when using "folder paths" like `/library/tvshows/123456/`, therefore, I'm using query parameters.
* When adding a path to the library, even if you enter it without a trailing slash, when you edit, it will have a slash appended.
* The routing library strips trailing slashes, but Kodi expects a trailing slash. This in combination with the previous line causes some headache.
* There is no way to add sources programmatically, therefore, the best we can do is indicate the user to read the README, and add a shortcut to the right screen where he can add the sources.

More information on the implementation: https://github.com/xbmc/xbmc/pull/13566 and https://github.com/xbmc/xbmc/pull/14210