### PR TITLE
Improve login flow

### DIFF
--- a/resources/lib/modules/authentication.py
+++ b/resources/lib/modules/authentication.py
@@ -5,10 +5,13 @@ from __future__ import absolute_import, division, unicode_literals
 
 import logging
 
+from requests import HTTPError
+
 from resources.lib import kodiutils
 from resources.lib.kodiutils import TitleItem
 from resources.lib.streamz.api import Api
 from resources.lib.streamz.auth import Auth
+from resources.lib.streamz.exceptions import InvalidLoginException, LoginErrorException, NoStreamzSubscriptionException, NoTelenetSubscriptionException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,6 +27,51 @@ class Authentication:
                           kodiutils.get_setting('profile'),
                           kodiutils.get_tokens_path())
         self._api = Api(self._auth)
+
+    @staticmethod
+    def verify_credentials():
+        """ Verify if the user has credentials and if they are valid. """
+        retry = False
+        while True:
+
+            # Check if the user has credentials
+            if retry or not kodiutils.get_setting('username') or not kodiutils.get_setting('password'):
+
+                # Ask user to fill in his credentials
+                if not kodiutils.yesno_dialog(message=kodiutils.localize(30701)):  # You need to configure your credentials...
+                    # The user doesn't want to do this. Abort to Home screen.
+                    return False
+
+                kodiutils.open_settings()
+
+            try:
+                # Create Auth object so we actually do a login.
+                Auth(kodiutils.get_setting('username'),
+                     kodiutils.get_setting('password'),
+                     kodiutils.get_setting('loginprovider'),
+                     kodiutils.get_setting('profile'),
+                     kodiutils.get_tokens_path())
+                return True
+
+            except InvalidLoginException:
+                kodiutils.ok_dialog(message=kodiutils.localize(30203))  # Your credentials are not valid!
+                retry = True
+
+            except NoStreamzSubscriptionException:
+                kodiutils.ok_dialog(message=kodiutils.localize(30201))  # Your Streamz account has no valid subscription!
+                retry = True
+
+            except NoTelenetSubscriptionException:
+                kodiutils.ok_dialog(message=kodiutils.localize(30202))  # Your Telenet account has no valid subscription!
+                retry = True
+
+            except LoginErrorException as exc:
+                kodiutils.ok_dialog(message=kodiutils.localize(30702, code=exc.code))  # Unknown error while logging in: {code}
+                return False
+
+            except HTTPError as exc:
+                kodiutils.ok_dialog(message=kodiutils.localize(30702, code='HTTP %d' % exc.response.status_code))  # Unknown error while logging in: {code}
+                return False
 
     def select_profile(self, key=None):
         """ Show your profiles.

--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -33,7 +33,7 @@ class BackgroundService(Monitor):
                 self._update_metadata()
 
             # Stop when abort requested
-            if self.waitForAbort(10):
+            if self.waitForAbort(60):
                 break
 
         _LOGGER.debug('Service stopped')
@@ -53,7 +53,13 @@ class BackgroundService(Monitor):
             success = Metadata().fetch_metadata(callback=update_status)
         except NoLoginException:
             # We have no login yet, but that's okay, we will retry later
-            success = True
+            _LOGGER.debug('Skipping background updating since we have no credentials.')
+            return
+
+        except Exception as exc:  # pylint: disable=broad-except
+            _LOGGER.debug('Skipping background updating since we got an error')
+            _LOGGER.exception(exc)
+            return
 
         # Update metadata_last_updated
         if success:


### PR DESCRIPTION
* Don't raise errors when refreshing in the background service.
* Validates the login when opening the Add-on and asks the user if he wants to enter the credentials. When they are incorrect, the question is asked again until the credentials are correct, or the user wants to stop.

Fixes #14 