### PR TITLE
Allow displaying all items in a recommendation category

### DIFF
--- a/resources/lib/modules/catalog.py
+++ b/resources/lib/modules/catalog.py
@@ -8,6 +8,7 @@ import logging
 from resources.lib import kodiutils
 from resources.lib.kodiutils import TitleItem
 from resources.lib.modules.menu import Menu
+from resources.lib.streamz import Category, STOREFRONT_SERIES, STOREFRONT_MOVIES
 from resources.lib.streamz.api import CACHE_PREVENT, Api
 from resources.lib.streamz.auth import Auth
 from resources.lib.streamz.exceptions import UnavailableException
@@ -57,7 +58,7 @@ class Catalog:
 
         # Sort items by label, but don't put folders at the top.
         # Used for A-Z listing or when movies and episodes are mixed.
-        kodiutils.show_listing(listing, 30003, content='movies' if category == 'films' else 'tvshows', sort=['label', 'year', 'duration'])
+        kodiutils.show_listing(listing, 30003, content='files', sort=['label', 'year', 'duration'])
 
     def show_program(self, program):
         """ Show a program from the catalog.
@@ -119,7 +120,7 @@ class Catalog:
             ))
 
         # Sort by label. Some programs return seasons unordered.
-        kodiutils.show_listing(listing, 30003, content='tvshows', sort=['label'])
+        kodiutils.show_listing(listing, program_obj.name, content='tvshows', sort=['label'])
 
     def show_program_season(self, program, season):
         """ Show the episodes of a program from the catalog.
@@ -144,27 +145,36 @@ class Catalog:
         listing = [Menu.generate_titleitem(e) for s in seasons for e in list(s.episodes.values())]
 
         # Sort by episode number by default. Takes seasons into account.
-        kodiutils.show_listing(listing, 30003, content='episodes', sort=['episode', 'duration'])
+        kodiutils.show_listing(listing, program_obj.name, content='episodes', sort=['episode', 'duration'])
 
     def show_recommendations(self, storefront):
         """ Show the recommendations.
 
         :type storefront: str
         """
-        recommendations = self._api.get_recommendations(storefront)
+        results = self._api.get_storefront(storefront)
 
         listing = []
-        for cat in recommendations:
-            listing.append(TitleItem(
-                title=cat.title,
-                path=kodiutils.url_for('show_recommendations_category', storefront=storefront, category=cat.category_id),
-                info_dict=dict(
-                    plot='[B]{category}[/B]'.format(category=cat.title),
-                ),
-            ))
+        for item in results:
+            if isinstance(item, Category):
+                listing.append(TitleItem(
+                    title=item.title,
+                    path=kodiutils.url_for('show_recommendations_category', storefront=storefront, category=item.category_id),
+                    info_dict=dict(
+                        plot='[B]{category}[/B]'.format(category=item.title),
+                    ),
+                ))
+            else:
+                listing.append(Menu.generate_titleitem(item))
 
-        # Sort categories by default like in Streamz.
-        kodiutils.show_listing(listing, 30015, content='files')
+        if storefront == STOREFRONT_SERIES:
+            label = 30005  # Series
+        elif storefront == STOREFRONT_MOVIES:
+            label = 30003  # Movies
+        else:
+            label = 30015  # Recommendations
+
+        kodiutils.show_listing(listing, label, content='files')
 
     def show_recommendations_category(self, storefront, category):
         """ Show the items in a recommendations category.
@@ -172,19 +182,20 @@ class Catalog:
         :type storefront: str
         :type category: str
         """
-        recommendations = self._api.get_recommendations(storefront)
+        result = self._api.get_storefront_category(storefront, category)
 
         listing = []
-        for cat in recommendations:
-            # Only show the requested category
-            if cat.category_id != category:
-                continue
+        for item in result.content:
+            listing.append(Menu.generate_titleitem(item))
 
-            for item in cat.content:
-                listing.append(Menu.generate_titleitem(item))
+        if storefront == STOREFRONT_SERIES:
+            content = 'tvshows'
+        elif storefront == STOREFRONT_MOVIES:
+            content = 'movies'
+        else:
+            content = 'files'
 
-        # Sort categories by default like in Streamz.
-        kodiutils.show_listing(listing, 30015, content='tvshows', sort=['unsorted', 'label', 'year', 'duration'])
+        kodiutils.show_listing(listing, result.title, content=content, sort=['unsorted', 'label', 'year', 'duration'])
 
     def show_mylist(self):
         """ Show the items in "My List". """
@@ -196,7 +207,7 @@ class Catalog:
             listing.append(Menu.generate_titleitem(item))
 
         # Sort categories by default like in Streamz.
-        kodiutils.show_listing(listing, 30017, content='tvshows', sort=['unsorted', 'label', 'year', 'duration'])
+        kodiutils.show_listing(listing, 30017, content='files', sort=['unsorted', 'label', 'year', 'duration'])
 
     def mylist_add(self, video_type, content_id):
         """ Add an item to "My List".

--- a/resources/lib/streamz/api.py
+++ b/resources/lib/streamz/api.py
@@ -46,38 +46,69 @@ class Api:
         # This contains a player.updateIntervalSeconds that could be used to notify Streamz about the playing progress
         return info
 
-    def get_recommendations(self, storefront):
-        """ Returns the config for the dashboard.
+    def get_storefront(self, storefront):
+        """ Returns a storefront.
 
-         :param str storefront:         The ID of the listing.
-         :rtype: list[Category]
+         :param str storefront:         The ID of the storefront.
+         :rtype: list[Category|Program|Movie]
          """
         response = util.http_get(API_ENDPOINT + '/%s/storefronts/%s' % (self._mode(), storefront),
                                  token=self._tokens.jwt_token,
                                  profile=self._tokens.profile)
-        recommendations = json.loads(response.text)
+        result = json.loads(response.text)
 
-        categories = []
-        for cat in recommendations.get('rows', []):
-            if cat.get('rowType') not in ['SWIMLANE_DEFAULT']:
-                _LOGGER.debug('Skipping recommendation %s with type %s', cat.get('title'), cat.get('rowType'))
+        items = []
+        for row in result.get('rows', []):
+            if row.get('rowType') == 'SWIMLANE_DEFAULT':
+                items.append(Category(
+                    category_id=row.get('id'),
+                    title=row.get('title'),
+                ))
                 continue
 
-            items = []
-            for item in cat.get('teasers'):
+            if row.get('rowType') == 'CAROUSEL':
+                for item in row.get('teasers'):
+                    if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE:
+                        items.append(self._parse_movie_teaser(item))
+
+                    elif item.get('target', {}).get('type') == CONTENT_TYPE_PROGRAM:
+                        items.append(self._parse_program_teaser(item))
+                continue
+
+            if row.get('rowType') == 'MARKETING_BLOCK':
+                item = row.get('teaser')
                 if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE:
                     items.append(self._parse_movie_teaser(item))
 
                 elif item.get('target', {}).get('type') == CONTENT_TYPE_PROGRAM:
                     items.append(self._parse_program_teaser(item))
+                continue
 
-            categories.append(Category(
-                category_id=cat.get('id'),
-                title=cat.get('title'),
-                content=items,
-            ))
+            _LOGGER.debug('Skipping recommendation %s with type %s', row.get('title'), row.get('rowType'))
 
-        return categories
+        return items
+
+    def get_storefront_category(self, storefront, category):
+        """ Returns a storefront.
+
+         :param str storefront:         The ID of the storefront.
+         :param str category:           The ID of the category.
+         :rtype: Category
+         """
+        response = util.http_get(API_ENDPOINT + '/%s/storefronts/%s/detail/%s' % (self._mode(), storefront, category),
+                                 token=self._tokens.jwt_token,
+                                 profile=self._tokens.profile)
+        result = json.loads(response.text)
+
+        items = []
+        for item in result.get('row', {}).get('teasers'):
+            if item.get('target', {}).get('type') == CONTENT_TYPE_MOVIE:
+                items.append(self._parse_movie_teaser(item))
+
+            elif item.get('target', {}).get('type') == CONTENT_TYPE_PROGRAM:
+                items.append(self._parse_program_teaser(item))
+
+        return Category(category_id=category, title=result.get('row', {}).get('title'), content=items)
 
     def get_swimlane(self, swimlane, content_filter=None, cache=CACHE_ONLY):
         """ Returns the contents of My List """
@@ -419,8 +450,9 @@ class Api:
         """
         movie = self.get_movie(item.get('target', {}).get('id'), cache=cache)
         if movie:
-            # We have a cover from the overview that we don't have in the details
-            movie.cover = item.get('imageUrl')
+            # We might have a cover from the overview that we don't have in the details
+            if item.get('imageUrl'):
+                movie.cover = item.get('imageUrl')
             return movie
 
         return Movie(
@@ -439,8 +471,9 @@ class Api:
         """
         program = self.get_program(item.get('target', {}).get('id'), cache=cache)
         if program:
-            # We have a cover from the overview that we don't have in the details
-            program.cover = item.get('imageUrl')
+            # We might have a cover from the overview that we don't have in the details
+            if item.get('imageUrl'):
+                program.cover = item.get('imageUrl')
             return program
 
         return Program(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -35,13 +35,13 @@ class TestApi(unittest.TestCase):
         self.assertTrue(items)
 
     def test_recommendations(self):
-        main_recommendations = self.api.get_recommendations(STOREFRONT_MAIN)
+        main_recommendations = self.api.get_storefront(STOREFRONT_MAIN)
         self.assertIsInstance(main_recommendations, list)
 
-        movie_recommendations = self.api.get_recommendations(STOREFRONT_MOVIES)
+        movie_recommendations = self.api.get_storefront(STOREFRONT_MOVIES)
         self.assertIsInstance(movie_recommendations, list)
 
-        serie_recommendations = self.api.get_recommendations(STOREFRONT_SERIES)
+        serie_recommendations = self.api.get_storefront(STOREFRONT_SERIES)
         self.assertIsInstance(serie_recommendations, list)
 
     def test_continuewatching(self):


### PR DESCRIPTION
* Use an API to fetch the details of the categories instead of using the overview that is limited to 40 items. This allows to display more then 40 items in a category, and also speeds up the loading of the overview of the categories since we don't need to parse everything there.
* Show highlighted movies or series inside recommendations / movies / series.
* Improve breadcrumbs

Fixes #11 and fixes #19 