### PR TITLE
Add proxy to modify the MPEG DASH Manifest

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -14,6 +14,7 @@ disable=
     too-many-instance-attributes,
     too-many-locals,
     too-many-public-methods,
+    too-many-statements,
 
     super-with-arguments, # Python 2.7 compatibility
     raise-missing-from, # Python 2.7 compatibility

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -185,6 +185,11 @@ msgctxt "#30716"
 msgid "Updating metadata ({index}/{total})..."
 msgstr ""
 
+msgctxt "#30718"
+msgid "The Manifest proxy is not running. Please restart Kodi."
+msgstr ""
+
+
 ### SETTINGS
 msgctxt "#30800"
 msgid "Credentials"
@@ -360,6 +365,10 @@ msgstr ""
 
 msgctxt "#30887"
 msgid "InputStream Helper settings…"
+msgstr ""
+
+msgctxt "#30888"
+msgid "Modify the MPEG DASH Manifest to workaround an InputStream Adaptive bug"
 msgstr ""
 
 msgctxt "#30889"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -186,6 +186,11 @@ msgctxt "#30716"
 msgid "Updating metadata ({index}/{total})..."
 msgstr "Vernieuwen metadata ({index}/{total})..."
 
+msgctxt "#30718"
+msgid "The Manifest proxy is not running. Please restart Kodi."
+msgstr "De Manifest-proxy is niet gestart. Gelieve Kodi te herstarten."
+
+
 ### SETTINGS
 msgctxt "#30800"
 msgid "Credentials"
@@ -363,6 +368,10 @@ msgstr "InputStream Adaptive configuratie…"
 msgctxt "#30887"
 msgid "InputStream Helper settings…"
 msgstr "InputStream Helper configuratie…"
+
+msgctxt "#30888"
+msgid "Modify the MPEG DASH Manifest to workaround an InputStream Adaptive bug"
+msgstr "Pas de MPEG DASH Manifest aan om rond een bug in InputStream Adaptive te werken"
 
 msgctxt "#30889"
 msgid "Logging"

--- a/resources/lib/modules/player.py
+++ b/resources/lib/modules/player.py
@@ -115,14 +115,32 @@ class Player:
             # This allows to play some programs that don't have metadata (yet).
             pass
 
+        # If we have enabled the Manifest proxy, route the call trough that.
+        if kodiutils.get_setting_bool('manifest_proxy'):
+            try:  # Python 3
+                from urllib.parse import urlencode
+            except ImportError:  # Python 2
+                from urllib import urlencode
+
+            port = kodiutils.get_setting_int('manifest_proxy_port')
+            if not port:
+                kodiutils.notification(message=kodiutils.localize(30718), icon='error')
+                kodiutils.end_of_directory()
+                return
+
+            url = 'http://127.0.0.1:{port}/manifest?{path}'.format(port=port,
+                                                                   path=urlencode({'path': resolved_stream.url}))
+        else:
+            url = resolved_stream.url
+
         license_key = self._stream.create_license_key(resolved_stream.license_url)
 
         # Play this item
-        kodiutils.play(resolved_stream.url, license_key, resolved_stream.title, {}, info_dict, prop_dict, stream_dict)
+        kodiutils.play(url, license_key, resolved_stream.title, {}, info_dict, prop_dict, stream_dict)
 
         # Wait for playback to start
         kodi_player = KodiPlayer()
-        if not kodi_player.waitForPlayBack(url=resolved_stream.url):
+        if not kodi_player.waitForPlayBack(url=url):
             # Playback didn't start
             return
 

--- a/resources/lib/modules/proxy.py
+++ b/resources/lib/modules/proxy.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+""" Kodi Manifest Proxy
+
+This Proxy is used to workaround an Inputstream Adaptive bug. For more info, see:
+* https://github.com/add-ons/plugin.video.vtm.go/issues/241
+* https://github.com/peak3d/inputstream.adaptive/pull/565
+* https://github.com/peak3d/inputstream.adaptive/pull/566
+"""
+
+from __future__ import absolute_import, division, unicode_literals
+
+import logging
+import re
+import threading
+
+import requests
+
+from resources.lib import kodiutils
+
+try:  # Python 3
+    from http.server import BaseHTTPRequestHandler
+except ImportError:  # Python 2
+    from BaseHTTPServer import BaseHTTPRequestHandler
+
+try:  # Python 3
+    from socketserver import TCPServer
+except ImportError:  # Python 2
+    from SocketServer import TCPServer
+
+try:  # Python 3
+    from urllib.parse import urlparse, parse_qs
+except ImportError:  # Python 2
+    from urlparse import urlparse, parse_qs
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Proxy(BaseHTTPRequestHandler):
+    """ Manifest Proxy to workaround a Inputstream Adaptive bug """
+    server_inst = None
+
+    @staticmethod
+    def start():
+        """ Start the Proxy. """
+
+        def start_proxy():
+            """ Start the Proxy. """
+            Proxy.server_inst = TCPServer(('127.0.0.1', 0), Proxy)
+            port = Proxy.server_inst.socket.getsockname()[1]
+            kodiutils.set_setting('manifest_proxy_port', str(port))
+            _LOGGER.debug('Listening on port %s', port)
+
+            # Start listening
+            Proxy.server_inst.serve_forever()
+
+        thread = threading.Thread(target=start_proxy)
+        thread.start()
+
+        return thread
+
+    @staticmethod
+    def stop():
+        """ Stop the Proxy. """
+        if Proxy.server_inst:
+            Proxy.server_inst.shutdown()
+
+    def do_GET(self):  # pylint: disable=invalid-name
+        """ Handle http get requests, used for manifest. """
+        _LOGGER.debug('HTTP GET Request received for %s', self.path)
+
+        if not self.path.startswith('/manifest'):
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        try:
+            # Make real request
+            params = parse_qs(urlparse(self.path).query)
+            url = params.get('path')[0]
+            _LOGGER.debug('Proxying to %s', url)
+            response = requests.get(url=url)
+
+            # Return response code
+            self.send_response(response.status_code)
+            self.end_headers()
+
+            if response.status_code == 200:
+                self.wfile.write(self.modify_manifest(response.text).encode())
+            else:
+                self.wfile.write(response.content)
+
+        except Exception as exc:  # pylint: disable=broad-except
+            _LOGGER.exception(exc)
+            self.send_response(500)
+            self.end_headers()
+
+    @staticmethod
+    def modify_manifest(manifest):
+        """ Modify the manifest so Inputstream Adaptive can handle it. """
+
+        def repl(matchobj):
+            """ Modify an AdaptationSet. We will be removing the BaseURL and prefixing it with the URL's in all SegmentTemplates. """
+            adaptationset = matchobj.group(0)
+
+            # Only process AdaptationSets that use a SegmentTemplate
+            if '<SegmentTemplate' not in adaptationset:
+                return adaptationset
+
+            # Extract BaseURL
+            match = re.search(r'<BaseURL>(.*?)</BaseURL>', adaptationset)
+            if not match:
+                return adaptationset
+            base_url = match.group(1)
+
+            # Remove BaseURL
+            adaptationset = re.sub(r'\s*?<BaseURL>.*?</BaseURL>', '', adaptationset)
+
+            # Prefix BaseURL on initialization=" and media=" tags
+            adaptationset = re.sub(r'(<SegmentTemplate[^>]*?initialization=\")([^\"]*)(\"[^>]*?>)', r'\1' + base_url + r'\2\3', adaptationset)
+            adaptationset = re.sub(r'(<SegmentTemplate[^>]*?media=\")([^\"]*)(\"[^>]*?>)', r'\1' + base_url + r'\2\3', adaptationset)
+
+            return adaptationset
+
+        # Process all AdaptationSets
+        output = re.sub(r'<AdaptationSet[^>]*>(.*?)</AdaptationSet>', repl, manifest, flags=re.DOTALL)
+
+        return output

--- a/resources/lib/service.py
+++ b/resources/lib/service.py
@@ -9,6 +9,7 @@ from time import time
 from xbmc import Monitor
 
 from resources.lib import kodilogging, kodiutils
+from resources.lib.modules.proxy import Proxy
 from resources.lib.streamz.exceptions import NoLoginException
 
 kodilogging.config()
@@ -20,12 +21,18 @@ class BackgroundService(Monitor):
 
     def __init__(self):
         Monitor.__init__(self)
+        self._proxy_thread = None
         self.update_interval = 24 * 3600  # Every 24 hours
         self.cache_expiry = 30 * 24 * 3600  # One month
 
     def run(self):
         """ Background loop for maintenance tasks """
         _LOGGER.debug('Service started')
+
+        kodiutils.set_setting('manifest_proxy_port', None)
+        if kodiutils.get_setting_bool('manifest_proxy'):
+            _LOGGER.debug('Starting Manifest Proxy...')
+            self._proxy_thread = Proxy.start()
 
         while not self.abortRequested():
             # Update every `update_interval` after the last update
@@ -35,6 +42,11 @@ class BackgroundService(Monitor):
             # Stop when abort requested
             if self.waitForAbort(60):
                 break
+
+        # Wait for the proxy thread to stop
+        if self._proxy_thread and self._proxy_thread.is_alive():
+            _LOGGER.debug('Stopping Manifest Proxy...')
+            Proxy.stop()
 
         _LOGGER.debug('Service stopped')
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -47,6 +47,8 @@
         <setting label="30883" type="action" id="ishelper_info" action="RunScript(script.module.inputstreamhelper, info)"/>
         <setting label="30885" type="action" id="adaptive_settings" option="close" action="Addon.OpenSettings(inputstream.adaptive)" visible="System.HasAddon(inputstream.adaptive) + [String.StartsWith(System.BuildVersion,18) | String.StartsWith(System.BuildVersion,19)]"/>
         <setting label="30887" type="action" id="ishelper_settings" option="close" action="Addon.OpenSettings(script.module.inputstreamhelper)"/>
+        <setting label="30888" type="bool" id="manifest_proxy" default="true"/>
+        <setting id="manifest_proxy_port" visible="false"/>
         <setting label="30889" type="lsep"/> <!-- Logging -->
         <setting label="30891" type="bool" id="debug_logging" default="false"/>
         <setting label="30892" type="action" action="InstallAddon(script.kodi.loguploader)" option="close" visible="!System.HasAddon(script.kodi.loguploader)"/> <!-- Install Kodi Logfile Uploader -->

--- a/tests/manifest_rewrite/manifest_01_input.xml
+++ b/tests/manifest_rewrite/manifest_01_input.xml
@@ -1,0 +1,228 @@
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="urn:microsoft:playready" minBufferTime="PT1.500000S" type="static" mediaPresentationDuration="PT0H36M41.682S" anvatoCdnProvider="akamai" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period duration="PT0H0M15.070S" id="1">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-video.mp4" media="$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="96530E9E30784944AB5AC59AF45634F5/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="0E84E1AABAE646138FC3777F5A7EA128/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="2195F4DE65E944039B45090D8003DF61/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="E79E2A5E2FDD4213BFDF444C6F299DDE/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="42E0BC1CA05C496380DA617160069F76/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="71E321DD8F0D4DFB81E2DEA7148EE544/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-audio.mp4" media="$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="96530E9E30784944AB5AC59AF45634F5/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M2.949S" id="2">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-video.mp4" media="$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="2949"/>
+      <Representation id="6571B7577EBB4AA1A9F9AC5DCB519AB9/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="314DE13883264592A00406B71065FEBA/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="1DE215965EA148348BF4746A542C96A8/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="EE1D56EBDA4942F884DDA88BCA829131/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="738AC39461784FEBA7F791110242E320/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="DD2B2ADEF1C9473CB0CD48D13D055D12/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-audio.mp4" media="$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="2949"/>
+      <Representation id="6571B7577EBB4AA1A9F9AC5DCB519AB9/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period id="3" duration="PT0H18M6.067S">
+    <AdaptationSet mimeType="audio/mp4" lang="en">
+      <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0"/>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/>
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" default_KID="002ec768-1168-274d-626b-638243f3a71d"/>
+      <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/</BaseURL>
+      <SegmentTemplate initialization="audio-$RepresentationID$-init.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" media="audio-$RepresentationID$-$Number$.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" startNumber="1" timescale="44100" presentationTimeOffset="0" duration="176128">
+
+                </SegmentTemplate>
+      <Representation codecs="mp4a.40.2" audioSamplingRate="44100" bandwidth="202003" id="D5BFAC7F2E6EFFCA55F45206D144AF9397974DAE8C3D1A8">
+                                                            </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="video/mp4">
+      <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0"/>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/>
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" default_KID="022ec768-1168-274d-626b-638243f3a71d"/>
+      <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/</BaseURL>
+      <SegmentTemplate initialization="video-$RepresentationID$-init.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" media="video-$RepresentationID$-$Number$.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" startNumber="1" timescale="10000" presentationTimeOffset="0" duration="40000">
+
+                </SegmentTemplate>
+      <Representation codecs="avc1.640028" width="1920" height="1080" bandwidth="4699047" id="D5BFAC7F2E6EFFCA55F45206D144AF9397974DAE8C3D1A8">
+                                                            </Representation>
+      <Representation codecs="avc1.64001f" width="1280" height="720" bandwidth="3161791" id="4F555FE1D1E2D2A37B6BF17D2A8864F6715D5541D11987">
+                                                            </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="video/mp4">
+      <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0"/>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/>
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" default_KID="012ec768-1168-274d-626b-638243f3a71d"/>
+      <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/</BaseURL>
+      <SegmentTemplate initialization="video-$RepresentationID$-init.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" media="video-$RepresentationID$-$Number$.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" startNumber="1" timescale="10000" presentationTimeOffset="0" duration="40000">
+
+                </SegmentTemplate>
+      <Representation codecs="avc1.64001f" width="960" height="540" bandwidth="1592999" id="2D8B974EAB53A2BFCFE9CBC25AEAF165F5EBA12A8DC445">
+                                                            </Representation>
+      <Representation codecs="avc1.64001e" width="640" height="360" bandwidth="811806" id="38559878811EC45CD97D59B7577DD137B4430CCEEE8382D">
+                                                            </Representation>
+      <Representation codecs="avc1.64000d" width="412" height="232" bandwidth="420053" id="B0395DA3FE569D71B9493EF894EEE43175C5ACAA6765787">
+                                                            </Representation>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M25.008S" id="4">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-video.mp4" media="$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="E9E0E4885F214B1E8892720E761E4CB7/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="391575B1E6424FC5A1112587A1AA712D/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="5151460EF9F94997AB2C17EA9216B59E/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="36EB9334EBC1404AA3CE4AB06DE9B487/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="44994BAB1D334176B88EC5A77D469F98/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="9D403754ECB940A1A4270CBE1ED41683/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-audio.mp4" media="$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="E9E0E4885F214B1E8892720E761E4CB7/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M20.434S" id="5">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-video.mp4" media="$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="F21FE903FB7B4315B6327B057A9B03D2/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="607F82181A984231A3886E67C743AA5C/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="15CEEF1DB35B4FC0B9A82D51208F208A/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="5E13E544EA79476ABC7C8ACD62F6755B/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="DB53CD4BA9AD45579103023FB11FF501/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="A982793E7F354A10AE527DE49720CFB9/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-audio.mp4" media="$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="F21FE903FB7B4315B6327B057A9B03D2/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M30.024S" id="6">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-video.mp4" media="$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="D6ECB9321EBC48688E11500625AC68A4/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="EE39964EF625430AACB5A773960B4615/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="00D5F625AB664117972B3CD9C5033559/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="473F9205F123458281B1DC816B55A2EB/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="B712D7E57FD0443E9ADD600E7BBE7186/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="DE769007EA4C40C4B491ED5461C42954/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-audio.mp4" media="$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="D6ECB9321EBC48688E11500625AC68A4/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M30.024S" id="7">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-video.mp4" media="$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="CCCCFECF383B4657AB9FAC04BE9B6C41/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="13E02F865E6B49DDB0C331855C1C702B/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="A16DAF3572EF4BD3B7054136E524FE75/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="4DE7FDFCBB2D4BDE9FBBFB8B78730B17/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="1689D5FA653E46D9BA75724C0244BE98/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="500915E524FF44FCA8AFB9854F295570/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-audio.mp4" media="$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="CCCCFECF383B4657AB9FAC04BE9B6C41/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M15.023S" id="8">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-video.mp4" media="$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="E637813D95684897A46D151FC05C63DF/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="8A1ED15243844028B29D73E4FF348F84/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="ADE165B22B314378B9286E227337E234/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="BDFE912939214CC4A7711C8F27880D84/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="7FCF44606D1C4BF18A8AD9571844E1E9/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="4515AF20767344B092B92051F3464D88/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-audio.mp4" media="$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="E637813D95684897A46D151FC05C63DF/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M51.967S" id="9">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-video.mp4" media="$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="033FC0C0EAC443FD9826CAC0D16989ED/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="BC7589099A22442E9C31E513ED923423/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="506A03FACFFB4E7487A906C6C7710A8C/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="BFA6807CAC264CBBBEAB27DC4BAB9A55/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="EF8C74626D3F462A9DDA072A82020FDA/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="25AAC68AEF4E4AD682701527DD65D1AA/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-audio.mp4" media="$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="033FC0C0EAC443FD9826CAC0D16989ED/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period id="10" duration="PT0H15M25.116S">
+    <AdaptationSet mimeType="audio/mp4" lang="en">
+      <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0"/>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/>
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" default_KID="002ec768-1168-274d-626b-638243f3a71d"/>
+      <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/</BaseURL>
+      <SegmentTemplate initialization="audio-$RepresentationID$-init.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" media="audio-$RepresentationID$-$Number$.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" startNumber="273" timescale="44100" presentationTimeOffset="47895552" duration="176128">
+
+                </SegmentTemplate>
+      <Representation codecs="mp4a.40.2" audioSamplingRate="44100" bandwidth="202003" id="D5BFAC7F2E6EFFCA55F45206D144AF9397974DAE8C3D1A8">
+                                                            </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="video/mp4">
+      <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0"/>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/>
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" default_KID="022ec768-1168-274d-626b-638243f3a71d"/>
+      <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/</BaseURL>
+      <SegmentTemplate initialization="video-$RepresentationID$-init.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" media="video-$RepresentationID$-$Number$.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" startNumber="273" timescale="10000" presentationTimeOffset="10860800" duration="40000">
+
+                </SegmentTemplate>
+      <Representation codecs="avc1.640028" width="1920" height="1080" bandwidth="4699047" id="D5BFAC7F2E6EFFCA55F45206D144AF9397974DAE8C3D1A8">
+                                                            </Representation>
+      <Representation codecs="avc1.64001f" width="1280" height="720" bandwidth="3161791" id="4F555FE1D1E2D2A37B6BF17D2A8864F6715D5541D11987">
+                                                            </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="video/mp4">
+      <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0"/>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/>
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" default_KID="012ec768-1168-274d-626b-638243f3a71d"/>
+      <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/</BaseURL>
+      <SegmentTemplate initialization="video-$RepresentationID$-init.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" media="video-$RepresentationID$-$Number$.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" startNumber="273" timescale="10000" presentationTimeOffset="10860800" duration="40000">
+
+                </SegmentTemplate>
+      <Representation codecs="avc1.64001f" width="960" height="540" bandwidth="1592999" id="2D8B974EAB53A2BFCFE9CBC25AEAF165F5EBA12A8DC445">
+                                                            </Representation>
+      <Representation codecs="avc1.64001e" width="640" height="360" bandwidth="811806" id="38559878811EC45CD97D59B7577DD137B4430CCEEE8382D">
+                                                            </Representation>
+      <Representation codecs="avc1.64000d" width="412" height="232" bandwidth="420053" id="B0395DA3FE569D71B9493EF894EEE43175C5ACAA6765787">
+                                                            </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/manifest_rewrite/manifest_01_output.xml
+++ b/tests/manifest_rewrite/manifest_01_output.xml
@@ -1,0 +1,206 @@
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="urn:microsoft:playready" minBufferTime="PT1.500000S" type="static" mediaPresentationDuration="PT0H36M41.682S" anvatoCdnProvider="akamai" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period duration="PT0H0M15.070S" id="1">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-video.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="96530E9E30784944AB5AC59AF45634F5/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="0E84E1AABAE646138FC3777F5A7EA128/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="2195F4DE65E944039B45090D8003DF61/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="E79E2A5E2FDD4213BFDF444C6F299DDE/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="42E0BC1CA05C496380DA617160069F76/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="71E321DD8F0D4DFB81E2DEA7148EE544/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-audio.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="96530E9E30784944AB5AC59AF45634F5/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M2.949S" id="2">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-video.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="2949"/>
+      <Representation id="6571B7577EBB4AA1A9F9AC5DCB519AB9/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="314DE13883264592A00406B71065FEBA/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="1DE215965EA148348BF4746A542C96A8/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="EE1D56EBDA4942F884DDA88BCA829131/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="738AC39461784FEBA7F791110242E320/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="DD2B2ADEF1C9473CB0CD48D13D055D12/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-audio.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="2949"/>
+      <Representation id="6571B7577EBB4AA1A9F9AC5DCB519AB9/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period id="3" duration="PT0H18M6.067S">
+    <AdaptationSet mimeType="audio/mp4" lang="en">
+      <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0"/>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/>
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" default_KID="002ec768-1168-274d-626b-638243f3a71d"/>
+      <SegmentTemplate initialization="https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/audio-$RepresentationID$-init.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" media="https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/audio-$RepresentationID$-$Number$.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" startNumber="1" timescale="44100" presentationTimeOffset="0" duration="176128">
+
+                </SegmentTemplate>
+      <Representation codecs="mp4a.40.2" audioSamplingRate="44100" bandwidth="202003" id="D5BFAC7F2E6EFFCA55F45206D144AF9397974DAE8C3D1A8">
+                                                            </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="video/mp4">
+      <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0"/>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/>
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" default_KID="022ec768-1168-274d-626b-638243f3a71d"/>
+      <SegmentTemplate initialization="https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/video-$RepresentationID$-init.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" media="https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/video-$RepresentationID$-$Number$.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" startNumber="1" timescale="10000" presentationTimeOffset="0" duration="40000">
+
+                </SegmentTemplate>
+      <Representation codecs="avc1.640028" width="1920" height="1080" bandwidth="4699047" id="D5BFAC7F2E6EFFCA55F45206D144AF9397974DAE8C3D1A8">
+                                                            </Representation>
+      <Representation codecs="avc1.64001f" width="1280" height="720" bandwidth="3161791" id="4F555FE1D1E2D2A37B6BF17D2A8864F6715D5541D11987">
+                                                            </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="video/mp4">
+      <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0"/>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/>
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" default_KID="012ec768-1168-274d-626b-638243f3a71d"/>
+      <SegmentTemplate initialization="https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/video-$RepresentationID$-init.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" media="https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/video-$RepresentationID$-$Number$.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" startNumber="1" timescale="10000" presentationTimeOffset="0" duration="40000">
+
+                </SegmentTemplate>
+      <Representation codecs="avc1.64001f" width="960" height="540" bandwidth="1592999" id="2D8B974EAB53A2BFCFE9CBC25AEAF165F5EBA12A8DC445">
+                                                            </Representation>
+      <Representation codecs="avc1.64001e" width="640" height="360" bandwidth="811806" id="38559878811EC45CD97D59B7577DD137B4430CCEEE8382D">
+                                                            </Representation>
+      <Representation codecs="avc1.64000d" width="412" height="232" bandwidth="420053" id="B0395DA3FE569D71B9493EF894EEE43175C5ACAA6765787">
+                                                            </Representation>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M25.008S" id="4">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-video.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="E9E0E4885F214B1E8892720E761E4CB7/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="391575B1E6424FC5A1112587A1AA712D/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="5151460EF9F94997AB2C17EA9216B59E/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="36EB9334EBC1404AA3CE4AB06DE9B487/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="44994BAB1D334176B88EC5A77D469F98/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="9D403754ECB940A1A4270CBE1ED41683/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-audio.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="E9E0E4885F214B1E8892720E761E4CB7/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M20.434S" id="5">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-video.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="F21FE903FB7B4315B6327B057A9B03D2/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="607F82181A984231A3886E67C743AA5C/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="15CEEF1DB35B4FC0B9A82D51208F208A/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="5E13E544EA79476ABC7C8ACD62F6755B/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="DB53CD4BA9AD45579103023FB11FF501/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="A982793E7F354A10AE527DE49720CFB9/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-audio.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="F21FE903FB7B4315B6327B057A9B03D2/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M30.024S" id="6">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-video.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="D6ECB9321EBC48688E11500625AC68A4/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="EE39964EF625430AACB5A773960B4615/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="00D5F625AB664117972B3CD9C5033559/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="473F9205F123458281B1DC816B55A2EB/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="B712D7E57FD0443E9ADD600E7BBE7186/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="DE769007EA4C40C4B491ED5461C42954/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-audio.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="D6ECB9321EBC48688E11500625AC68A4/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M30.024S" id="7">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-video.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="CCCCFECF383B4657AB9FAC04BE9B6C41/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="13E02F865E6B49DDB0C331855C1C702B/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="A16DAF3572EF4BD3B7054136E524FE75/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="4DE7FDFCBB2D4BDE9FBBFB8B78730B17/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="1689D5FA653E46D9BA75724C0244BE98/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="500915E524FF44FCA8AFB9854F295570/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-audio.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="CCCCFECF383B4657AB9FAC04BE9B6C41/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M15.023S" id="8">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-video.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="E637813D95684897A46D151FC05C63DF/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="8A1ED15243844028B29D73E4FF348F84/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="ADE165B22B314378B9286E227337E234/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="BDFE912939214CC4A7711C8F27880D84/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="7FCF44606D1C4BF18A8AD9571844E1E9/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="4515AF20767344B092B92051F3464D88/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-audio.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="E637813D95684897A46D151FC05C63DF/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M51.967S" id="9">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-video.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="033FC0C0EAC443FD9826CAC0D16989ED/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <Representation id="BC7589099A22442E9C31E513ED923423/2200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="2200000" width="1280" height="720" frameRate="60/2"/>
+      <Representation id="506A03FACFFB4E7487A906C6C7710A8C/1600000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1600000" width="960" height="540" frameRate="60/2"/>
+      <Representation id="BFA6807CAC264CBBBEAB27DC4BAB9A55/1000000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="1000000" width="640" height="360" frameRate="60/2"/>
+      <Representation id="EF8C74626D3F462A9DDA072A82020FDA/350000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="350000" width="448" height="252" frameRate="60/2"/>
+      <Representation id="25AAC68AEF4E4AD682701527DD65D1AA/120000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="120000" width="320" height="180" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-audio.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="033FC0C0EAC443FD9826CAC0D16989ED/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period id="10" duration="PT0H15M25.116S">
+    <AdaptationSet mimeType="audio/mp4" lang="en">
+      <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0"/>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/>
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" default_KID="002ec768-1168-274d-626b-638243f3a71d"/>
+      <SegmentTemplate initialization="https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/audio-$RepresentationID$-init.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" media="https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/audio-$RepresentationID$-$Number$.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" startNumber="273" timescale="44100" presentationTimeOffset="47895552" duration="176128">
+
+                </SegmentTemplate>
+      <Representation codecs="mp4a.40.2" audioSamplingRate="44100" bandwidth="202003" id="D5BFAC7F2E6EFFCA55F45206D144AF9397974DAE8C3D1A8">
+                                                            </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="video/mp4">
+      <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0"/>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/>
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" default_KID="022ec768-1168-274d-626b-638243f3a71d"/>
+      <SegmentTemplate initialization="https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/video-$RepresentationID$-init.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" media="https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/video-$RepresentationID$-$Number$.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" startNumber="273" timescale="10000" presentationTimeOffset="10860800" duration="40000">
+
+                </SegmentTemplate>
+      <Representation codecs="avc1.640028" width="1920" height="1080" bandwidth="4699047" id="D5BFAC7F2E6EFFCA55F45206D144AF9397974DAE8C3D1A8">
+                                                            </Representation>
+      <Representation codecs="avc1.64001f" width="1280" height="720" bandwidth="3161791" id="4F555FE1D1E2D2A37B6BF17D2A8864F6715D5541D11987">
+                                                            </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="video/mp4">
+      <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0"/>
+      <ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/>
+      <ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" default_KID="012ec768-1168-274d-626b-638243f3a71d"/>
+      <SegmentTemplate initialization="https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/video-$RepresentationID$-init.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" media="https://dpp-anvato-live.akamaized.net/eu/vod/10000001/20/11/26/10213236/video-$RepresentationID$-$Number$.mp4?hdntl=exp=1609100759~acl=/*~hmac=8fa595ba401926af677d70fa67129d4439284a6a0d373c6ba538341ef5a18904" startNumber="273" timescale="10000" presentationTimeOffset="10860800" duration="40000">
+
+                </SegmentTemplate>
+      <Representation codecs="avc1.64001f" width="960" height="540" bandwidth="1592999" id="2D8B974EAB53A2BFCFE9CBC25AEAF165F5EBA12A8DC445">
+                                                            </Representation>
+      <Representation codecs="avc1.64001e" width="640" height="360" bandwidth="811806" id="38559878811EC45CD97D59B7577DD137B4430CCEEE8382D">
+                                                            </Representation>
+      <Representation codecs="avc1.64000d" width="412" height="232" bandwidth="420053" id="B0395DA3FE569D71B9493EF894EEE43175C5ACAA6765787">
+                                                            </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/manifest_rewrite/manifest_02_input.xml
+++ b/tests/manifest_rewrite/manifest_02_input.xml
@@ -1,0 +1,391 @@
+<?xml version="1.0"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="urn:microsoft:playready" minBufferTime="PT1.500000S" type="static" mediaPresentationDuration="PT0H3M46.600S" anvatoCdnProvider="akamai" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period id="1" duration="PT0H3M46.600S">
+    <AdaptationSet mimeType="audio/mp4" lang="en"><ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0">
+          <mspr:pro>xAEAAAEAAQC6ATwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AOABUAGMAMwBEAFUANAA4AGQAUgB5AHcARgA5AG0AVwBJAGUAdABMADQAQQA9AD0APAAvAEsASQBEAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</mspr:pro>
+          <cenc:pssh>AAAB5HBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAcTEAQAAAQABALoBPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgA4AFQAYwAzAEQAVQA0ADgAZABSAHkAdwBGADkAbQBXAEkAZQB0AEwANABBAD0APQA8AC8ASwBJAEQAPgA8AC8ARABBAFQAQQA+ADwALwBXAFIATQBIAEUAQQBEAEUAUgA+AA==</cenc:pssh>
+        </ContentProtection><ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/><ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="0d3737f13c4e1c75b017d99621eb4be0"/>
+      <Representation codecs="mp4a.40.2" audioSamplingRate="44100" bandwidth="201790" id="201790">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/audio-4383E931245193D547FA16C7C89DAADF6A27732EDA9B8633.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="262952" timescale="44100">
+          <Initialization range="0-1283"/>
+          <SegmentURL mediaRange="1284-150731"/>
+          <SegmentURL mediaRange="150732-302410"/>
+          <SegmentURL mediaRange="302411-453809"/>
+          <SegmentURL mediaRange="453810-605234"/>
+          <SegmentURL mediaRange="605235-756300"/>
+          <SegmentURL mediaRange="756301-907294"/>
+          <SegmentURL mediaRange="907295-1058989"/>
+          <SegmentURL mediaRange="1058990-1210570"/>
+          <SegmentURL mediaRange="1210571-1362057"/>
+          <SegmentURL mediaRange="1362058-1513154"/>
+          <SegmentURL mediaRange="1513155-1664155"/>
+          <SegmentURL mediaRange="1664156-1815812"/>
+          <SegmentURL mediaRange="1815813-1967412"/>
+          <SegmentURL mediaRange="1967413-2118531"/>
+          <SegmentURL mediaRange="2118532-2269732"/>
+          <SegmentURL mediaRange="2269733-2420830"/>
+          <SegmentURL mediaRange="2420831-2572627"/>
+          <SegmentURL mediaRange="2572628-2723834"/>
+          <SegmentURL mediaRange="2723835-2875247"/>
+          <SegmentURL mediaRange="2875248-3026489"/>
+          <SegmentURL mediaRange="3026490-3177884"/>
+          <SegmentURL mediaRange="3177885-3329624"/>
+          <SegmentURL mediaRange="3329625-3480527"/>
+          <SegmentURL mediaRange="3480528-3632138"/>
+          <SegmentURL mediaRange="3632139-3783084"/>
+          <SegmentURL mediaRange="3783085-3934195"/>
+          <SegmentURL mediaRange="3934196-4086115"/>
+          <SegmentURL mediaRange="4086116-4237409"/>
+          <SegmentURL mediaRange="4237410-4388844"/>
+          <SegmentURL mediaRange="4388845-4540138"/>
+          <SegmentURL mediaRange="4540139-4691207"/>
+          <SegmentURL mediaRange="4691208-4842756"/>
+          <SegmentURL mediaRange="4842757-4994190"/>
+          <SegmentURL mediaRange="4994191-5145562"/>
+          <SegmentURL mediaRange="5145563-5296746"/>
+          <SegmentURL mediaRange="5296747-5447966"/>
+          <SegmentURL mediaRange="5447967-5599577"/>
+          <SegmentURL mediaRange="5599578-5716553"/>
+        </SegmentList>
+      </Representation>
+      <Representation codecs="mp4a.40.2" audioSamplingRate="44100" bandwidth="171789" id="171789">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/audio-3C5B2418D65AC298189E6B311736EAA9CD634F2D289560.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="262952" timescale="44100">
+          <Initialization range="0-1283"/>
+          <SegmentURL mediaRange="1284-128476"/>
+          <SegmentURL mediaRange="128477-257707"/>
+          <SegmentURL mediaRange="257708-386609"/>
+          <SegmentURL mediaRange="386610-515625"/>
+          <SegmentURL mediaRange="515626-644451"/>
+          <SegmentURL mediaRange="644452-772546"/>
+          <SegmentURL mediaRange="772547-901855"/>
+          <SegmentURL mediaRange="901856-1030808"/>
+          <SegmentURL mediaRange="1030809-1159816"/>
+          <SegmentURL mediaRange="1159817-1288489"/>
+          <SegmentURL mediaRange="1288490-1416983"/>
+          <SegmentURL mediaRange="1416984-1546084"/>
+          <SegmentURL mediaRange="1546085-1675188"/>
+          <SegmentURL mediaRange="1675189-1803934"/>
+          <SegmentURL mediaRange="1803935-1932607"/>
+          <SegmentURL mediaRange="1932608-2061173"/>
+          <SegmentURL mediaRange="2061174-2190449"/>
+          <SegmentURL mediaRange="2190450-2319212"/>
+          <SegmentURL mediaRange="2319213-2448232"/>
+          <SegmentURL mediaRange="2448233-2576785"/>
+          <SegmentURL mediaRange="2576786-2705736"/>
+          <SegmentURL mediaRange="2705737-2834895"/>
+          <SegmentURL mediaRange="2834896-2963347"/>
+          <SegmentURL mediaRange="2963348-3092327"/>
+          <SegmentURL mediaRange="3092328-3220798"/>
+          <SegmentURL mediaRange="3220799-3349459"/>
+          <SegmentURL mediaRange="3349460-3478890"/>
+          <SegmentURL mediaRange="3478891-3607736"/>
+          <SegmentURL mediaRange="3607737-3736524"/>
+          <SegmentURL mediaRange="3736525-3865411"/>
+          <SegmentURL mediaRange="3865412-3994038"/>
+          <SegmentURL mediaRange="3994039-4123046"/>
+          <SegmentURL mediaRange="4123047-4252037"/>
+          <SegmentURL mediaRange="4252038-4380854"/>
+          <SegmentURL mediaRange="4380855-4509561"/>
+          <SegmentURL mediaRange="4509562-4638295"/>
+          <SegmentURL mediaRange="4638296-4767360"/>
+          <SegmentURL mediaRange="4767361-4866834"/>
+        </SegmentList>
+      </Representation>
+      <Representation codecs="mp4a.40.2" audioSamplingRate="44100" bandwidth="139789" id="139789">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/audio-18B74B8CDC5FE8FC943CAC32ED05367F5E223A4F783DAF.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="262952" timescale="44100">
+          <Initialization range="0-1283"/>
+          <SegmentURL mediaRange="1284-104824"/>
+          <SegmentURL mediaRange="104825-210135"/>
+          <SegmentURL mediaRange="210136-315035"/>
+          <SegmentURL mediaRange="315036-419989"/>
+          <SegmentURL mediaRange="419990-524803"/>
+          <SegmentURL mediaRange="524804-629073"/>
+          <SegmentURL mediaRange="629074-734312"/>
+          <SegmentURL mediaRange="734313-839161"/>
+          <SegmentURL mediaRange="839162-944195"/>
+          <SegmentURL mediaRange="944196-1048987"/>
+          <SegmentURL mediaRange="1048988-1153459"/>
+          <SegmentURL mediaRange="1153460-1258546"/>
+          <SegmentURL mediaRange="1258547-1363542"/>
+          <SegmentURL mediaRange="1363543-1468301"/>
+          <SegmentURL mediaRange="1468302-1573137"/>
+          <SegmentURL mediaRange="1573138-1677634"/>
+          <SegmentURL mediaRange="1677635-1782851"/>
+          <SegmentURL mediaRange="1782852-1887674"/>
+          <SegmentURL mediaRange="1887675-1992577"/>
+          <SegmentURL mediaRange="1992578-2097195"/>
+          <SegmentURL mediaRange="2097196-2202079"/>
+          <SegmentURL mediaRange="2202080-2307225"/>
+          <SegmentURL mediaRange="2307226-2411794"/>
+          <SegmentURL mediaRange="2411795-2516754"/>
+          <SegmentURL mediaRange="2516755-2621085"/>
+          <SegmentURL mediaRange="2621086-2725823"/>
+          <SegmentURL mediaRange="2725824-2831273"/>
+          <SegmentURL mediaRange="2831274-2936195"/>
+          <SegmentURL mediaRange="2936196-3040960"/>
+          <SegmentURL mediaRange="3040961-3145807"/>
+          <SegmentURL mediaRange="3145808-3250487"/>
+          <SegmentURL mediaRange="3250488-3355496"/>
+          <SegmentURL mediaRange="3355497-3460415"/>
+          <SegmentURL mediaRange="3460416-3565309"/>
+          <SegmentURL mediaRange="3565310-3670001"/>
+          <SegmentURL mediaRange="3670002-3774732"/>
+          <SegmentURL mediaRange="3774733-3879736"/>
+          <SegmentURL mediaRange="3879737-3960525"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="video/mp4"><ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0">
+          <mspr:pro>xAEAAAEAAQC6ATwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AOABUAGMAMwBEAFUANAA4AGQAUgB5AHcARgA5AG0AVwBJAGUAdABMADQAQQA9AD0APAAvAEsASQBEAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</mspr:pro>
+          <cenc:pssh>AAAB5HBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAcTEAQAAAQABALoBPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgA4AFQAYwAzAEQAVQA0ADgAZABSAHkAdwBGADkAbQBXAEkAZQB0AEwANABBAD0APQA8AC8ASwBJAEQAPgA8AC8ARABBAFQAQQA+ADwALwBXAFIATQBIAEUAQQBEAEUAUgA+AA==</cenc:pssh>
+        </ContentProtection><ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/><ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="0d3737f13c4e1c75b017d99621eb4be0"/>
+      <Representation codecs="avc1.640028" width="1920" height="1080" bandwidth="3523086" id="3523086">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/video-4383E931245193D547FA16C7C89DAADF6A27732EDA9B8633.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="59631" timescale="10000">
+          <Initialization range="0-1364"/>
+          <SegmentURL mediaRange="1365-3065852"/>
+          <SegmentURL mediaRange="3065853-5777401"/>
+          <SegmentURL mediaRange="5777402-8128381"/>
+          <SegmentURL mediaRange="8128382-10919834"/>
+          <SegmentURL mediaRange="10919835-13790019"/>
+          <SegmentURL mediaRange="13790020-16336558"/>
+          <SegmentURL mediaRange="16336559-19297003"/>
+          <SegmentURL mediaRange="19297004-21507794"/>
+          <SegmentURL mediaRange="21507795-24698050"/>
+          <SegmentURL mediaRange="24698051-27304274"/>
+          <SegmentURL mediaRange="27304275-29456199"/>
+          <SegmentURL mediaRange="29456200-32390803"/>
+          <SegmentURL mediaRange="32390804-35281697"/>
+          <SegmentURL mediaRange="35281698-37542677"/>
+          <SegmentURL mediaRange="37542678-40160215"/>
+          <SegmentURL mediaRange="40160216-42985925"/>
+          <SegmentURL mediaRange="42985926-45572312"/>
+          <SegmentURL mediaRange="45572313-48257276"/>
+          <SegmentURL mediaRange="48257277-51099213"/>
+          <SegmentURL mediaRange="51099214-53745616"/>
+          <SegmentURL mediaRange="53745617-56362594"/>
+          <SegmentURL mediaRange="56362595-59209725"/>
+          <SegmentURL mediaRange="59209726-61425526"/>
+          <SegmentURL mediaRange="61425527-64135704"/>
+          <SegmentURL mediaRange="64135705-66860805"/>
+          <SegmentURL mediaRange="66860806-69467483"/>
+          <SegmentURL mediaRange="69467484-72360799"/>
+          <SegmentURL mediaRange="72360800-74935200"/>
+          <SegmentURL mediaRange="74935201-77625297"/>
+          <SegmentURL mediaRange="77625298-80202194"/>
+          <SegmentURL mediaRange="80202195-83013921"/>
+          <SegmentURL mediaRange="83013922-85623480"/>
+          <SegmentURL mediaRange="85623481-88137770"/>
+          <SegmentURL mediaRange="88137771-90840131"/>
+          <SegmentURL mediaRange="90840132-93828938"/>
+          <SegmentURL mediaRange="93828939-96344887"/>
+          <SegmentURL mediaRange="96344888-98896328"/>
+          <SegmentURL mediaRange="98896329-99792822"/>
+        </SegmentList>
+      </Representation>
+      <Representation codecs="avc1.64001f" width="1280" height="720" bandwidth="2344242" id="2344242">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/video-3C5B2418D65AC298189E6B311736EAA9CD634F2D289560.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="59631" timescale="10000">
+          <Initialization range="0-1363"/>
+          <SegmentURL mediaRange="1364-2025966"/>
+          <SegmentURL mediaRange="2025967-3830629"/>
+          <SegmentURL mediaRange="3830630-5423172"/>
+          <SegmentURL mediaRange="5423173-7282934"/>
+          <SegmentURL mediaRange="7282935-9203367"/>
+          <SegmentURL mediaRange="9203368-10895689"/>
+          <SegmentURL mediaRange="10895690-12891408"/>
+          <SegmentURL mediaRange="12891409-14340833"/>
+          <SegmentURL mediaRange="14340834-16462559"/>
+          <SegmentURL mediaRange="16462560-18191850"/>
+          <SegmentURL mediaRange="18191851-19615356"/>
+          <SegmentURL mediaRange="19615357-21563281"/>
+          <SegmentURL mediaRange="21563282-23482958"/>
+          <SegmentURL mediaRange="23482959-24961690"/>
+          <SegmentURL mediaRange="24961691-26674914"/>
+          <SegmentURL mediaRange="26674915-28557996"/>
+          <SegmentURL mediaRange="28557997-30277515"/>
+          <SegmentURL mediaRange="30277516-32063520"/>
+          <SegmentURL mediaRange="32063521-33934082"/>
+          <SegmentURL mediaRange="33934083-35696114"/>
+          <SegmentURL mediaRange="35696115-37439786"/>
+          <SegmentURL mediaRange="37439787-39354416"/>
+          <SegmentURL mediaRange="39354417-40903547"/>
+          <SegmentURL mediaRange="40903548-42697804"/>
+          <SegmentURL mediaRange="42697805-44494521"/>
+          <SegmentURL mediaRange="44494522-46215557"/>
+          <SegmentURL mediaRange="46215558-48178339"/>
+          <SegmentURL mediaRange="48178340-49921651"/>
+          <SegmentURL mediaRange="49921652-51732050"/>
+          <SegmentURL mediaRange="51732051-53408491"/>
+          <SegmentURL mediaRange="53408492-55290501"/>
+          <SegmentURL mediaRange="55290502-57020079"/>
+          <SegmentURL mediaRange="57020080-58668455"/>
+          <SegmentURL mediaRange="58668456-60460134"/>
+          <SegmentURL mediaRange="60460135-62482969"/>
+          <SegmentURL mediaRange="62482970-64146906"/>
+          <SegmentURL mediaRange="64146907-65834623"/>
+          <SegmentURL mediaRange="65834624-66402071"/>
+        </SegmentList>
+      </Representation>
+      <Representation codecs="avc1.64001f" width="960" height="540" bandwidth="1175734" id="1175734">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/video-B1EE8355C1CF6511B48E84FD2CC21E70B2269B9E96845E0.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="59631" timescale="10000">
+          <Initialization range="0-1363"/>
+          <SegmentURL mediaRange="1364-1037118"/>
+          <SegmentURL mediaRange="1037119-1927717"/>
+          <SegmentURL mediaRange="1927718-2719123"/>
+          <SegmentURL mediaRange="2719124-3622920"/>
+          <SegmentURL mediaRange="3622921-4595442"/>
+          <SegmentURL mediaRange="4595443-5452763"/>
+          <SegmentURL mediaRange="5452764-6453429"/>
+          <SegmentURL mediaRange="6453430-7183050"/>
+          <SegmentURL mediaRange="7183051-8254324"/>
+          <SegmentURL mediaRange="8254325-9113213"/>
+          <SegmentURL mediaRange="9113214-9819204"/>
+          <SegmentURL mediaRange="9819205-10814965"/>
+          <SegmentURL mediaRange="10814966-11759806"/>
+          <SegmentURL mediaRange="11759807-12491162"/>
+          <SegmentURL mediaRange="12491163-13358206"/>
+          <SegmentURL mediaRange="13358207-14327371"/>
+          <SegmentURL mediaRange="14327372-15168133"/>
+          <SegmentURL mediaRange="15168134-16094417"/>
+          <SegmentURL mediaRange="16094418-17012497"/>
+          <SegmentURL mediaRange="17012498-17895649"/>
+          <SegmentURL mediaRange="17895650-18773485"/>
+          <SegmentURL mediaRange="18773486-19751059"/>
+          <SegmentURL mediaRange="19751060-20526283"/>
+          <SegmentURL mediaRange="20526284-21451256"/>
+          <SegmentURL mediaRange="21451257-22332753"/>
+          <SegmentURL mediaRange="22332754-23204911"/>
+          <SegmentURL mediaRange="23204912-24168474"/>
+          <SegmentURL mediaRange="24168475-25057864"/>
+          <SegmentURL mediaRange="25057865-25944585"/>
+          <SegmentURL mediaRange="25944586-26788864"/>
+          <SegmentURL mediaRange="26788865-27732986"/>
+          <SegmentURL mediaRange="27732987-28592786"/>
+          <SegmentURL mediaRange="28592787-29411007"/>
+          <SegmentURL mediaRange="29411008-30314887"/>
+          <SegmentURL mediaRange="30314888-31325407"/>
+          <SegmentURL mediaRange="31325408-32146814"/>
+          <SegmentURL mediaRange="32146815-32986919"/>
+          <SegmentURL mediaRange="32986920-33304078"/>
+        </SegmentList>
+      </Representation>
+      <Representation codecs="avc1.64001e" width="640" height="360" bandwidth="594327" id="594327">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/video-18B74B8CDC5FE8FC943CAC32ED05367F5E223A4F783DAF.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="59631" timescale="10000">
+          <Initialization range="0-1363"/>
+          <SegmentURL mediaRange="1364-519813"/>
+          <SegmentURL mediaRange="519814-968064"/>
+          <SegmentURL mediaRange="968065-1366239"/>
+          <SegmentURL mediaRange="1366240-1810627"/>
+          <SegmentURL mediaRange="1810628-2303532"/>
+          <SegmentURL mediaRange="2303533-2749994"/>
+          <SegmentURL mediaRange="2749995-3238794"/>
+          <SegmentURL mediaRange="3238795-3610675"/>
+          <SegmentURL mediaRange="3610676-4149837"/>
+          <SegmentURL mediaRange="4149838-4586132"/>
+          <SegmentURL mediaRange="4586133-4948998"/>
+          <SegmentURL mediaRange="4948999-5459740"/>
+          <SegmentURL mediaRange="5459741-5929653"/>
+          <SegmentURL mediaRange="5929654-6310321"/>
+          <SegmentURL mediaRange="6310322-6749894"/>
+          <SegmentURL mediaRange="6749895-7256387"/>
+          <SegmentURL mediaRange="7256388-7669134"/>
+          <SegmentURL mediaRange="7669135-8153614"/>
+          <SegmentURL mediaRange="8153615-8597640"/>
+          <SegmentURL mediaRange="8597641-9039223"/>
+          <SegmentURL mediaRange="9039224-9483771"/>
+          <SegmentURL mediaRange="9483772-9988023"/>
+          <SegmentURL mediaRange="9988024-10378178"/>
+          <SegmentURL mediaRange="10378179-10859302"/>
+          <SegmentURL mediaRange="10859303-11303608"/>
+          <SegmentURL mediaRange="11303609-11756265"/>
+          <SegmentURL mediaRange="11756266-12216907"/>
+          <SegmentURL mediaRange="12216908-12669844"/>
+          <SegmentURL mediaRange="12669845-13127345"/>
+          <SegmentURL mediaRange="13127346-13558210"/>
+          <SegmentURL mediaRange="13558211-14038481"/>
+          <SegmentURL mediaRange="14038482-14465079"/>
+          <SegmentURL mediaRange="14465080-14874363"/>
+          <SegmentURL mediaRange="14874364-15337790"/>
+          <SegmentURL mediaRange="15337791-15839279"/>
+          <SegmentURL mediaRange="15839280-16255173"/>
+          <SegmentURL mediaRange="16255174-16682465"/>
+          <SegmentURL mediaRange="16682466-16835726"/>
+        </SegmentList>
+      </Representation>
+      <Representation codecs="avc1.64000d" width="416" height="236" bandwidth="301803" id="301803">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/video-5AF90912E78664F9A85B7DC5E23A8BDD93B3B0ECA3A3E4.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="59631" timescale="10000">
+          <Initialization range="0-1362"/>
+          <SegmentURL mediaRange="1363-258351"/>
+          <SegmentURL mediaRange="258352-485990"/>
+          <SegmentURL mediaRange="485991-682994"/>
+          <SegmentURL mediaRange="682995-913373"/>
+          <SegmentURL mediaRange="913374-1153711"/>
+          <SegmentURL mediaRange="1153712-1385890"/>
+          <SegmentURL mediaRange="1385891-1627992"/>
+          <SegmentURL mediaRange="1627993-1821634"/>
+          <SegmentURL mediaRange="1821635-2090632"/>
+          <SegmentURL mediaRange="2090633-2312171"/>
+          <SegmentURL mediaRange="2312172-2503211"/>
+          <SegmentURL mediaRange="2503212-2758717"/>
+          <SegmentURL mediaRange="2758718-2998600"/>
+          <SegmentURL mediaRange="2998601-3204354"/>
+          <SegmentURL mediaRange="3204355-3428880"/>
+          <SegmentURL mediaRange="3428881-3686745"/>
+          <SegmentURL mediaRange="3686746-3896829"/>
+          <SegmentURL mediaRange="3896830-4143350"/>
+          <SegmentURL mediaRange="4143351-4357891"/>
+          <SegmentURL mediaRange="4357892-4583380"/>
+          <SegmentURL mediaRange="4583381-4807996"/>
+          <SegmentURL mediaRange="4807997-5062172"/>
+          <SegmentURL mediaRange="5062173-5265818"/>
+          <SegmentURL mediaRange="5265819-5517327"/>
+          <SegmentURL mediaRange="5517328-5740271"/>
+          <SegmentURL mediaRange="5740272-5974495"/>
+          <SegmentURL mediaRange="5974496-6195048"/>
+          <SegmentURL mediaRange="6195049-6430642"/>
+          <SegmentURL mediaRange="6430643-6661240"/>
+          <SegmentURL mediaRange="6661241-6887322"/>
+          <SegmentURL mediaRange="6887323-7125837"/>
+          <SegmentURL mediaRange="7125838-7340965"/>
+          <SegmentURL mediaRange="7340966-7549661"/>
+          <SegmentURL mediaRange="7549662-7780035"/>
+          <SegmentURL mediaRange="7780036-8037970"/>
+          <SegmentURL mediaRange="8037971-8252840"/>
+          <SegmentURL mediaRange="8252841-8473012"/>
+          <SegmentURL mediaRange="8473013-8549991"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/manifest_rewrite/manifest_02_output.xml
+++ b/tests/manifest_rewrite/manifest_02_output.xml
@@ -1,0 +1,391 @@
+<?xml version="1.0"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="urn:microsoft:playready" minBufferTime="PT1.500000S" type="static" mediaPresentationDuration="PT0H3M46.600S" anvatoCdnProvider="akamai" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period id="1" duration="PT0H3M46.600S">
+    <AdaptationSet mimeType="audio/mp4" lang="en"><ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0">
+          <mspr:pro>xAEAAAEAAQC6ATwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AOABUAGMAMwBEAFUANAA4AGQAUgB5AHcARgA5AG0AVwBJAGUAdABMADQAQQA9AD0APAAvAEsASQBEAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</mspr:pro>
+          <cenc:pssh>AAAB5HBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAcTEAQAAAQABALoBPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgA4AFQAYwAzAEQAVQA0ADgAZABSAHkAdwBGADkAbQBXAEkAZQB0AEwANABBAD0APQA8AC8ASwBJAEQAPgA8AC8ARABBAFQAQQA+ADwALwBXAFIATQBIAEUAQQBEAEUAUgA+AA==</cenc:pssh>
+        </ContentProtection><ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/><ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="0d3737f13c4e1c75b017d99621eb4be0"/>
+      <Representation codecs="mp4a.40.2" audioSamplingRate="44100" bandwidth="201790" id="201790">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/audio-4383E931245193D547FA16C7C89DAADF6A27732EDA9B8633.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="262952" timescale="44100">
+          <Initialization range="0-1283"/>
+          <SegmentURL mediaRange="1284-150731"/>
+          <SegmentURL mediaRange="150732-302410"/>
+          <SegmentURL mediaRange="302411-453809"/>
+          <SegmentURL mediaRange="453810-605234"/>
+          <SegmentURL mediaRange="605235-756300"/>
+          <SegmentURL mediaRange="756301-907294"/>
+          <SegmentURL mediaRange="907295-1058989"/>
+          <SegmentURL mediaRange="1058990-1210570"/>
+          <SegmentURL mediaRange="1210571-1362057"/>
+          <SegmentURL mediaRange="1362058-1513154"/>
+          <SegmentURL mediaRange="1513155-1664155"/>
+          <SegmentURL mediaRange="1664156-1815812"/>
+          <SegmentURL mediaRange="1815813-1967412"/>
+          <SegmentURL mediaRange="1967413-2118531"/>
+          <SegmentURL mediaRange="2118532-2269732"/>
+          <SegmentURL mediaRange="2269733-2420830"/>
+          <SegmentURL mediaRange="2420831-2572627"/>
+          <SegmentURL mediaRange="2572628-2723834"/>
+          <SegmentURL mediaRange="2723835-2875247"/>
+          <SegmentURL mediaRange="2875248-3026489"/>
+          <SegmentURL mediaRange="3026490-3177884"/>
+          <SegmentURL mediaRange="3177885-3329624"/>
+          <SegmentURL mediaRange="3329625-3480527"/>
+          <SegmentURL mediaRange="3480528-3632138"/>
+          <SegmentURL mediaRange="3632139-3783084"/>
+          <SegmentURL mediaRange="3783085-3934195"/>
+          <SegmentURL mediaRange="3934196-4086115"/>
+          <SegmentURL mediaRange="4086116-4237409"/>
+          <SegmentURL mediaRange="4237410-4388844"/>
+          <SegmentURL mediaRange="4388845-4540138"/>
+          <SegmentURL mediaRange="4540139-4691207"/>
+          <SegmentURL mediaRange="4691208-4842756"/>
+          <SegmentURL mediaRange="4842757-4994190"/>
+          <SegmentURL mediaRange="4994191-5145562"/>
+          <SegmentURL mediaRange="5145563-5296746"/>
+          <SegmentURL mediaRange="5296747-5447966"/>
+          <SegmentURL mediaRange="5447967-5599577"/>
+          <SegmentURL mediaRange="5599578-5716553"/>
+        </SegmentList>
+      </Representation>
+      <Representation codecs="mp4a.40.2" audioSamplingRate="44100" bandwidth="171789" id="171789">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/audio-3C5B2418D65AC298189E6B311736EAA9CD634F2D289560.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="262952" timescale="44100">
+          <Initialization range="0-1283"/>
+          <SegmentURL mediaRange="1284-128476"/>
+          <SegmentURL mediaRange="128477-257707"/>
+          <SegmentURL mediaRange="257708-386609"/>
+          <SegmentURL mediaRange="386610-515625"/>
+          <SegmentURL mediaRange="515626-644451"/>
+          <SegmentURL mediaRange="644452-772546"/>
+          <SegmentURL mediaRange="772547-901855"/>
+          <SegmentURL mediaRange="901856-1030808"/>
+          <SegmentURL mediaRange="1030809-1159816"/>
+          <SegmentURL mediaRange="1159817-1288489"/>
+          <SegmentURL mediaRange="1288490-1416983"/>
+          <SegmentURL mediaRange="1416984-1546084"/>
+          <SegmentURL mediaRange="1546085-1675188"/>
+          <SegmentURL mediaRange="1675189-1803934"/>
+          <SegmentURL mediaRange="1803935-1932607"/>
+          <SegmentURL mediaRange="1932608-2061173"/>
+          <SegmentURL mediaRange="2061174-2190449"/>
+          <SegmentURL mediaRange="2190450-2319212"/>
+          <SegmentURL mediaRange="2319213-2448232"/>
+          <SegmentURL mediaRange="2448233-2576785"/>
+          <SegmentURL mediaRange="2576786-2705736"/>
+          <SegmentURL mediaRange="2705737-2834895"/>
+          <SegmentURL mediaRange="2834896-2963347"/>
+          <SegmentURL mediaRange="2963348-3092327"/>
+          <SegmentURL mediaRange="3092328-3220798"/>
+          <SegmentURL mediaRange="3220799-3349459"/>
+          <SegmentURL mediaRange="3349460-3478890"/>
+          <SegmentURL mediaRange="3478891-3607736"/>
+          <SegmentURL mediaRange="3607737-3736524"/>
+          <SegmentURL mediaRange="3736525-3865411"/>
+          <SegmentURL mediaRange="3865412-3994038"/>
+          <SegmentURL mediaRange="3994039-4123046"/>
+          <SegmentURL mediaRange="4123047-4252037"/>
+          <SegmentURL mediaRange="4252038-4380854"/>
+          <SegmentURL mediaRange="4380855-4509561"/>
+          <SegmentURL mediaRange="4509562-4638295"/>
+          <SegmentURL mediaRange="4638296-4767360"/>
+          <SegmentURL mediaRange="4767361-4866834"/>
+        </SegmentList>
+      </Representation>
+      <Representation codecs="mp4a.40.2" audioSamplingRate="44100" bandwidth="139789" id="139789">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/audio-18B74B8CDC5FE8FC943CAC32ED05367F5E223A4F783DAF.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="262952" timescale="44100">
+          <Initialization range="0-1283"/>
+          <SegmentURL mediaRange="1284-104824"/>
+          <SegmentURL mediaRange="104825-210135"/>
+          <SegmentURL mediaRange="210136-315035"/>
+          <SegmentURL mediaRange="315036-419989"/>
+          <SegmentURL mediaRange="419990-524803"/>
+          <SegmentURL mediaRange="524804-629073"/>
+          <SegmentURL mediaRange="629074-734312"/>
+          <SegmentURL mediaRange="734313-839161"/>
+          <SegmentURL mediaRange="839162-944195"/>
+          <SegmentURL mediaRange="944196-1048987"/>
+          <SegmentURL mediaRange="1048988-1153459"/>
+          <SegmentURL mediaRange="1153460-1258546"/>
+          <SegmentURL mediaRange="1258547-1363542"/>
+          <SegmentURL mediaRange="1363543-1468301"/>
+          <SegmentURL mediaRange="1468302-1573137"/>
+          <SegmentURL mediaRange="1573138-1677634"/>
+          <SegmentURL mediaRange="1677635-1782851"/>
+          <SegmentURL mediaRange="1782852-1887674"/>
+          <SegmentURL mediaRange="1887675-1992577"/>
+          <SegmentURL mediaRange="1992578-2097195"/>
+          <SegmentURL mediaRange="2097196-2202079"/>
+          <SegmentURL mediaRange="2202080-2307225"/>
+          <SegmentURL mediaRange="2307226-2411794"/>
+          <SegmentURL mediaRange="2411795-2516754"/>
+          <SegmentURL mediaRange="2516755-2621085"/>
+          <SegmentURL mediaRange="2621086-2725823"/>
+          <SegmentURL mediaRange="2725824-2831273"/>
+          <SegmentURL mediaRange="2831274-2936195"/>
+          <SegmentURL mediaRange="2936196-3040960"/>
+          <SegmentURL mediaRange="3040961-3145807"/>
+          <SegmentURL mediaRange="3145808-3250487"/>
+          <SegmentURL mediaRange="3250488-3355496"/>
+          <SegmentURL mediaRange="3355497-3460415"/>
+          <SegmentURL mediaRange="3460416-3565309"/>
+          <SegmentURL mediaRange="3565310-3670001"/>
+          <SegmentURL mediaRange="3670002-3774732"/>
+          <SegmentURL mediaRange="3774733-3879736"/>
+          <SegmentURL mediaRange="3879737-3960525"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="video/mp4"><ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0">
+          <mspr:pro>xAEAAAEAAQC6ATwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AOABUAGMAMwBEAFUANAA4AGQAUgB5AHcARgA5AG0AVwBJAGUAdABMADQAQQA9AD0APAAvAEsASQBEAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</mspr:pro>
+          <cenc:pssh>AAAB5HBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAcTEAQAAAQABALoBPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgA4AFQAYwAzAEQAVQA0ADgAZABSAHkAdwBGADkAbQBXAEkAZQB0AEwANABBAD0APQA8AC8ASwBJAEQAPgA8AC8ARABBAFQAQQA+ADwALwBXAFIATQBIAEUAQQBEAEUAUgA+AA==</cenc:pssh>
+        </ContentProtection><ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/><ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="0d3737f13c4e1c75b017d99621eb4be0"/>
+      <Representation codecs="avc1.640028" width="1920" height="1080" bandwidth="3523086" id="3523086">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/video-4383E931245193D547FA16C7C89DAADF6A27732EDA9B8633.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="59631" timescale="10000">
+          <Initialization range="0-1364"/>
+          <SegmentURL mediaRange="1365-3065852"/>
+          <SegmentURL mediaRange="3065853-5777401"/>
+          <SegmentURL mediaRange="5777402-8128381"/>
+          <SegmentURL mediaRange="8128382-10919834"/>
+          <SegmentURL mediaRange="10919835-13790019"/>
+          <SegmentURL mediaRange="13790020-16336558"/>
+          <SegmentURL mediaRange="16336559-19297003"/>
+          <SegmentURL mediaRange="19297004-21507794"/>
+          <SegmentURL mediaRange="21507795-24698050"/>
+          <SegmentURL mediaRange="24698051-27304274"/>
+          <SegmentURL mediaRange="27304275-29456199"/>
+          <SegmentURL mediaRange="29456200-32390803"/>
+          <SegmentURL mediaRange="32390804-35281697"/>
+          <SegmentURL mediaRange="35281698-37542677"/>
+          <SegmentURL mediaRange="37542678-40160215"/>
+          <SegmentURL mediaRange="40160216-42985925"/>
+          <SegmentURL mediaRange="42985926-45572312"/>
+          <SegmentURL mediaRange="45572313-48257276"/>
+          <SegmentURL mediaRange="48257277-51099213"/>
+          <SegmentURL mediaRange="51099214-53745616"/>
+          <SegmentURL mediaRange="53745617-56362594"/>
+          <SegmentURL mediaRange="56362595-59209725"/>
+          <SegmentURL mediaRange="59209726-61425526"/>
+          <SegmentURL mediaRange="61425527-64135704"/>
+          <SegmentURL mediaRange="64135705-66860805"/>
+          <SegmentURL mediaRange="66860806-69467483"/>
+          <SegmentURL mediaRange="69467484-72360799"/>
+          <SegmentURL mediaRange="72360800-74935200"/>
+          <SegmentURL mediaRange="74935201-77625297"/>
+          <SegmentURL mediaRange="77625298-80202194"/>
+          <SegmentURL mediaRange="80202195-83013921"/>
+          <SegmentURL mediaRange="83013922-85623480"/>
+          <SegmentURL mediaRange="85623481-88137770"/>
+          <SegmentURL mediaRange="88137771-90840131"/>
+          <SegmentURL mediaRange="90840132-93828938"/>
+          <SegmentURL mediaRange="93828939-96344887"/>
+          <SegmentURL mediaRange="96344888-98896328"/>
+          <SegmentURL mediaRange="98896329-99792822"/>
+        </SegmentList>
+      </Representation>
+      <Representation codecs="avc1.64001f" width="1280" height="720" bandwidth="2344242" id="2344242">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/video-3C5B2418D65AC298189E6B311736EAA9CD634F2D289560.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="59631" timescale="10000">
+          <Initialization range="0-1363"/>
+          <SegmentURL mediaRange="1364-2025966"/>
+          <SegmentURL mediaRange="2025967-3830629"/>
+          <SegmentURL mediaRange="3830630-5423172"/>
+          <SegmentURL mediaRange="5423173-7282934"/>
+          <SegmentURL mediaRange="7282935-9203367"/>
+          <SegmentURL mediaRange="9203368-10895689"/>
+          <SegmentURL mediaRange="10895690-12891408"/>
+          <SegmentURL mediaRange="12891409-14340833"/>
+          <SegmentURL mediaRange="14340834-16462559"/>
+          <SegmentURL mediaRange="16462560-18191850"/>
+          <SegmentURL mediaRange="18191851-19615356"/>
+          <SegmentURL mediaRange="19615357-21563281"/>
+          <SegmentURL mediaRange="21563282-23482958"/>
+          <SegmentURL mediaRange="23482959-24961690"/>
+          <SegmentURL mediaRange="24961691-26674914"/>
+          <SegmentURL mediaRange="26674915-28557996"/>
+          <SegmentURL mediaRange="28557997-30277515"/>
+          <SegmentURL mediaRange="30277516-32063520"/>
+          <SegmentURL mediaRange="32063521-33934082"/>
+          <SegmentURL mediaRange="33934083-35696114"/>
+          <SegmentURL mediaRange="35696115-37439786"/>
+          <SegmentURL mediaRange="37439787-39354416"/>
+          <SegmentURL mediaRange="39354417-40903547"/>
+          <SegmentURL mediaRange="40903548-42697804"/>
+          <SegmentURL mediaRange="42697805-44494521"/>
+          <SegmentURL mediaRange="44494522-46215557"/>
+          <SegmentURL mediaRange="46215558-48178339"/>
+          <SegmentURL mediaRange="48178340-49921651"/>
+          <SegmentURL mediaRange="49921652-51732050"/>
+          <SegmentURL mediaRange="51732051-53408491"/>
+          <SegmentURL mediaRange="53408492-55290501"/>
+          <SegmentURL mediaRange="55290502-57020079"/>
+          <SegmentURL mediaRange="57020080-58668455"/>
+          <SegmentURL mediaRange="58668456-60460134"/>
+          <SegmentURL mediaRange="60460135-62482969"/>
+          <SegmentURL mediaRange="62482970-64146906"/>
+          <SegmentURL mediaRange="64146907-65834623"/>
+          <SegmentURL mediaRange="65834624-66402071"/>
+        </SegmentList>
+      </Representation>
+      <Representation codecs="avc1.64001f" width="960" height="540" bandwidth="1175734" id="1175734">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/video-B1EE8355C1CF6511B48E84FD2CC21E70B2269B9E96845E0.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="59631" timescale="10000">
+          <Initialization range="0-1363"/>
+          <SegmentURL mediaRange="1364-1037118"/>
+          <SegmentURL mediaRange="1037119-1927717"/>
+          <SegmentURL mediaRange="1927718-2719123"/>
+          <SegmentURL mediaRange="2719124-3622920"/>
+          <SegmentURL mediaRange="3622921-4595442"/>
+          <SegmentURL mediaRange="4595443-5452763"/>
+          <SegmentURL mediaRange="5452764-6453429"/>
+          <SegmentURL mediaRange="6453430-7183050"/>
+          <SegmentURL mediaRange="7183051-8254324"/>
+          <SegmentURL mediaRange="8254325-9113213"/>
+          <SegmentURL mediaRange="9113214-9819204"/>
+          <SegmentURL mediaRange="9819205-10814965"/>
+          <SegmentURL mediaRange="10814966-11759806"/>
+          <SegmentURL mediaRange="11759807-12491162"/>
+          <SegmentURL mediaRange="12491163-13358206"/>
+          <SegmentURL mediaRange="13358207-14327371"/>
+          <SegmentURL mediaRange="14327372-15168133"/>
+          <SegmentURL mediaRange="15168134-16094417"/>
+          <SegmentURL mediaRange="16094418-17012497"/>
+          <SegmentURL mediaRange="17012498-17895649"/>
+          <SegmentURL mediaRange="17895650-18773485"/>
+          <SegmentURL mediaRange="18773486-19751059"/>
+          <SegmentURL mediaRange="19751060-20526283"/>
+          <SegmentURL mediaRange="20526284-21451256"/>
+          <SegmentURL mediaRange="21451257-22332753"/>
+          <SegmentURL mediaRange="22332754-23204911"/>
+          <SegmentURL mediaRange="23204912-24168474"/>
+          <SegmentURL mediaRange="24168475-25057864"/>
+          <SegmentURL mediaRange="25057865-25944585"/>
+          <SegmentURL mediaRange="25944586-26788864"/>
+          <SegmentURL mediaRange="26788865-27732986"/>
+          <SegmentURL mediaRange="27732987-28592786"/>
+          <SegmentURL mediaRange="28592787-29411007"/>
+          <SegmentURL mediaRange="29411008-30314887"/>
+          <SegmentURL mediaRange="30314888-31325407"/>
+          <SegmentURL mediaRange="31325408-32146814"/>
+          <SegmentURL mediaRange="32146815-32986919"/>
+          <SegmentURL mediaRange="32986920-33304078"/>
+        </SegmentList>
+      </Representation>
+      <Representation codecs="avc1.64001e" width="640" height="360" bandwidth="594327" id="594327">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/video-18B74B8CDC5FE8FC943CAC32ED05367F5E223A4F783DAF.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="59631" timescale="10000">
+          <Initialization range="0-1363"/>
+          <SegmentURL mediaRange="1364-519813"/>
+          <SegmentURL mediaRange="519814-968064"/>
+          <SegmentURL mediaRange="968065-1366239"/>
+          <SegmentURL mediaRange="1366240-1810627"/>
+          <SegmentURL mediaRange="1810628-2303532"/>
+          <SegmentURL mediaRange="2303533-2749994"/>
+          <SegmentURL mediaRange="2749995-3238794"/>
+          <SegmentURL mediaRange="3238795-3610675"/>
+          <SegmentURL mediaRange="3610676-4149837"/>
+          <SegmentURL mediaRange="4149838-4586132"/>
+          <SegmentURL mediaRange="4586133-4948998"/>
+          <SegmentURL mediaRange="4948999-5459740"/>
+          <SegmentURL mediaRange="5459741-5929653"/>
+          <SegmentURL mediaRange="5929654-6310321"/>
+          <SegmentURL mediaRange="6310322-6749894"/>
+          <SegmentURL mediaRange="6749895-7256387"/>
+          <SegmentURL mediaRange="7256388-7669134"/>
+          <SegmentURL mediaRange="7669135-8153614"/>
+          <SegmentURL mediaRange="8153615-8597640"/>
+          <SegmentURL mediaRange="8597641-9039223"/>
+          <SegmentURL mediaRange="9039224-9483771"/>
+          <SegmentURL mediaRange="9483772-9988023"/>
+          <SegmentURL mediaRange="9988024-10378178"/>
+          <SegmentURL mediaRange="10378179-10859302"/>
+          <SegmentURL mediaRange="10859303-11303608"/>
+          <SegmentURL mediaRange="11303609-11756265"/>
+          <SegmentURL mediaRange="11756266-12216907"/>
+          <SegmentURL mediaRange="12216908-12669844"/>
+          <SegmentURL mediaRange="12669845-13127345"/>
+          <SegmentURL mediaRange="13127346-13558210"/>
+          <SegmentURL mediaRange="13558211-14038481"/>
+          <SegmentURL mediaRange="14038482-14465079"/>
+          <SegmentURL mediaRange="14465080-14874363"/>
+          <SegmentURL mediaRange="14874364-15337790"/>
+          <SegmentURL mediaRange="15337791-15839279"/>
+          <SegmentURL mediaRange="15839280-16255173"/>
+          <SegmentURL mediaRange="16255174-16682465"/>
+          <SegmentURL mediaRange="16682466-16835726"/>
+        </SegmentList>
+      </Representation>
+      <Representation codecs="avc1.64000d" width="416" height="236" bandwidth="301803" id="301803">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/video-5AF90912E78664F9A85B7DC5E23A8BDD93B3B0ECA3A3E4.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+
+
+
+        <SegmentList duration="59631" timescale="10000">
+          <Initialization range="0-1362"/>
+          <SegmentURL mediaRange="1363-258351"/>
+          <SegmentURL mediaRange="258352-485990"/>
+          <SegmentURL mediaRange="485991-682994"/>
+          <SegmentURL mediaRange="682995-913373"/>
+          <SegmentURL mediaRange="913374-1153711"/>
+          <SegmentURL mediaRange="1153712-1385890"/>
+          <SegmentURL mediaRange="1385891-1627992"/>
+          <SegmentURL mediaRange="1627993-1821634"/>
+          <SegmentURL mediaRange="1821635-2090632"/>
+          <SegmentURL mediaRange="2090633-2312171"/>
+          <SegmentURL mediaRange="2312172-2503211"/>
+          <SegmentURL mediaRange="2503212-2758717"/>
+          <SegmentURL mediaRange="2758718-2998600"/>
+          <SegmentURL mediaRange="2998601-3204354"/>
+          <SegmentURL mediaRange="3204355-3428880"/>
+          <SegmentURL mediaRange="3428881-3686745"/>
+          <SegmentURL mediaRange="3686746-3896829"/>
+          <SegmentURL mediaRange="3896830-4143350"/>
+          <SegmentURL mediaRange="4143351-4357891"/>
+          <SegmentURL mediaRange="4357892-4583380"/>
+          <SegmentURL mediaRange="4583381-4807996"/>
+          <SegmentURL mediaRange="4807997-5062172"/>
+          <SegmentURL mediaRange="5062173-5265818"/>
+          <SegmentURL mediaRange="5265819-5517327"/>
+          <SegmentURL mediaRange="5517328-5740271"/>
+          <SegmentURL mediaRange="5740272-5974495"/>
+          <SegmentURL mediaRange="5974496-6195048"/>
+          <SegmentURL mediaRange="6195049-6430642"/>
+          <SegmentURL mediaRange="6430643-6661240"/>
+          <SegmentURL mediaRange="6661241-6887322"/>
+          <SegmentURL mediaRange="6887323-7125837"/>
+          <SegmentURL mediaRange="7125838-7340965"/>
+          <SegmentURL mediaRange="7340966-7549661"/>
+          <SegmentURL mediaRange="7549662-7780035"/>
+          <SegmentURL mediaRange="7780036-8037970"/>
+          <SegmentURL mediaRange="8037971-8252840"/>
+          <SegmentURL mediaRange="8252841-8473012"/>
+          <SegmentURL mediaRange="8473013-8549991"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/manifest_rewrite/manifest_03_input.xml
+++ b/tests/manifest_rewrite/manifest_03_input.xml
@@ -1,0 +1,51 @@
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="urn:microsoft:playready" minBufferTime="PT1.500000S" type="static" mediaPresentationDuration="PT0H3M46.600S" anvatoCdnProvider="akamai" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period duration="PT0H0M15.070S" id="1">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <!-- AdaptationSet with a BaseURL and a SegmentTemplate -->
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-video.mp4" media="$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="96530E9E30784944AB5AC59AF45634F5/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+      <SegmentTemplate initialization="$RepresentationID$-init-audio.mp4" media="$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="96530E9E30784944AB5AC59AF45634F5/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M2.949S" id="2">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <!-- AdaptationSet without a BaseURL and a SegmentTemplate -->
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-video.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="2949"/>
+      <Representation id="6571B7577EBB4AA1A9F9AC5DCB519AB9/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-audio.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="2949"/>
+      <Representation id="6571B7577EBB4AA1A9F9AC5DCB519AB9/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M15.070S" id="1">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <!-- AdaptationSet with a BaseURL at the bottom -->
+      <SegmentTemplate initialization="$RepresentationID$-init-video.mp4" media="$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="96530E9E30784944AB5AC59AF45634F5/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+      <BaseURL>https://dcs-jite.cdn.anvato.net/prod/v98/media/</BaseURL>
+    </AdaptationSet>
+  </Period>
+  <Period id="1" duration="PT0H3M46.600S">
+    <AdaptationSet mimeType="audio/mp4" lang="en"><ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0">
+          <mspr:pro>xAEAAAEAAQC6ATwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AOABUAGMAMwBEAFUANAA4AGQAUgB5AHcARgA5AG0AVwBJAGUAdABMADQAQQA9AD0APAAvAEsASQBEAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</mspr:pro>
+          <cenc:pssh>AAAB5HBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAcTEAQAAAQABALoBPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgA4AFQAYwAzAEQAVQA0ADgAZABSAHkAdwBGADkAbQBXAEkAZQB0AEwANABBAD0APQA8AC8ASwBJAEQAPgA8AC8ARABBAFQAQQA+ADwALwBXAFIATQBIAEUAQQBEAEUAUgA+AA==</cenc:pssh>
+        </ContentProtection><ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/><ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="0d3737f13c4e1c75b017d99621eb4be0"/>
+      <!-- AdaptationSet with a BaseURL and a SegmentList -->
+      <Representation codecs="mp4a.40.2" audioSamplingRate="44100" bandwidth="201790" id="201790">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/audio-4383E931245193D547FA16C7C89DAADF6A27732EDA9B8633.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+        <SegmentList duration="262952" timescale="44100">
+          <Initialization range="0-1283"/>
+          <SegmentURL mediaRange="1284-150731"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/manifest_rewrite/manifest_03_output.xml
+++ b/tests/manifest_rewrite/manifest_03_output.xml
@@ -1,0 +1,48 @@
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="urn:microsoft:playready" minBufferTime="PT1.500000S" type="static" mediaPresentationDuration="PT0H3M46.600S" anvatoCdnProvider="akamai" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period duration="PT0H0M15.070S" id="1">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <!-- AdaptationSet with a BaseURL and a SegmentTemplate -->
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-video.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="96530E9E30784944AB5AC59AF45634F5/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-audio.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="96530E9E30784944AB5AC59AF45634F5/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M2.949S" id="2">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <!-- AdaptationSet without a BaseURL and a SegmentTemplate -->
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-video.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="2949"/>
+      <Representation id="6571B7577EBB4AA1A9F9AC5DCB519AB9/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+    </AdaptationSet>
+    <AdaptationSet contentType="audio" segmentAlignment="true" bitstreamSwitching="true">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-audio.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-audio.mp4" startNumber="1" timescale="1000" duration="2949"/>
+      <Representation id="6571B7577EBB4AA1A9F9AC5DCB519AB9/4200000/fmp4" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000"/>
+    </AdaptationSet>
+  </Period>
+  <Period duration="PT0H0M15.070S" id="1">
+    <AdaptationSet contentType="video" segmentAlignment="true" bitstreamSwitching="true">
+      <!-- AdaptationSet with a BaseURL at the bottom -->
+      <SegmentTemplate initialization="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-init-video.mp4" media="https://dcs-jite.cdn.anvato.net/prod/v98/media/$RepresentationID$-$Number$-video.mp4" startNumber="1" timescale="1000" duration="9590"/>
+      <Representation id="96530E9E30784944AB5AC59AF45634F5/4200000/fmp4" mimeType="video/mp4" codecs="avc1.64001e" bandwidth="4200000" width="1920" height="1080" frameRate="60/2"/>
+    </AdaptationSet>
+  </Period>
+  <Period id="1" duration="PT0H3M46.600S">
+    <AdaptationSet mimeType="audio/mp4" lang="en"><ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0">
+          <mspr:pro>xAEAAAEAAQC6ATwAVwBSAE0ASABFAEEARABFAFIAIAB4AG0AbABuAHMAPQAiAGgAdAB0AHAAOgAvAC8AcwBjAGgAZQBtAGEAcwAuAG0AaQBjAHIAbwBzAG8AZgB0AC4AYwBvAG0ALwBEAFIATQAvADIAMAAwADcALwAwADMALwBQAGwAYQB5AFIAZQBhAGQAeQBIAGUAYQBkAGUAcgAiACAAdgBlAHIAcwBpAG8AbgA9ACIANAAuADAALgAwAC4AMAAiAD4APABEAEEAVABBAD4APABQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsARQBZAEwARQBOAD4AMQA2ADwALwBLAEUAWQBMAEUATgA+ADwAQQBMAEcASQBEAD4AQQBFAFMAQwBUAFIAPAAvAEEATABHAEkARAA+ADwALwBQAFIATwBUAEUAQwBUAEkATgBGAE8APgA8AEsASQBEAD4AOABUAGMAMwBEAFUANAA4AGQAUgB5AHcARgA5AG0AVwBJAGUAdABMADQAQQA9AD0APAAvAEsASQBEAD4APAAvAEQAQQBUAEEAPgA8AC8AVwBSAE0ASABFAEEARABFAFIAPgA=</mspr:pro>
+          <cenc:pssh>AAAB5HBzc2gAAAAAmgTweZhAQoarkuZb4IhflQAAAcTEAQAAAQABALoBPABXAFIATQBIAEUAQQBEAEUAUgAgAHgAbQBsAG4AcwA9ACIAaAB0AHQAcAA6AC8ALwBzAGMAaABlAG0AYQBzAC4AbQBpAGMAcgBvAHMAbwBmAHQALgBjAG8AbQAvAEQAUgBNAC8AMgAwADAANwAvADAAMwAvAFAAbABhAHkAUgBlAGEAZAB5AEgAZQBhAGQAZQByACIAIAB2AGUAcgBzAGkAbwBuAD0AIgA0AC4AMAAuADAALgAwACIAPgA8AEQAQQBUAEEAPgA8AFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBFAFkATABFAE4APgAxADYAPAAvAEsARQBZAEwARQBOAD4APABBAEwARwBJAEQAPgBBAEUAUwBDAFQAUgA8AC8AQQBMAEcASQBEAD4APAAvAFAAUgBPAFQARQBDAFQASQBOAEYATwA+ADwASwBJAEQAPgA4AFQAYwAzAEQAVQA0ADgAZABSAHkAdwBGADkAbQBXAEkAZQB0AEwANABBAD0APQA8AC8ASwBJAEQAPgA8AC8ARABBAFQAQQA+ADwALwBXAFIATQBIAEUAQQBEAEUAUgA+AA==</cenc:pssh>
+        </ContentProtection><ContentProtection schemeIdUri="urn:uuid:EDEF8BA9-79D6-4ACE-A3C8-27DCD51D21ED"/><ContentProtection value="cenc" schemeIdUri="urn:mpeg:dash:mp4protection:2011" cenc:default_KID="0d3737f13c4e1c75b017d99621eb4be0"/>
+      <!-- AdaptationSet with a BaseURL and a SegmentList -->
+      <Representation codecs="mp4a.40.2" audioSamplingRate="44100" bandwidth="201790" id="201790">
+        <BaseURL>https://dpp-anvato-live.akamaized.net/eu/vod/10000001/19/02/27/10018191/audio-4383E931245193D547FA16C7C89DAADF6A27732EDA9B8633.mp4?hdntl=exp=1609177121~acl=/*~hmac=80a6f5af59442c576f60e5ea61d41a7f0675d1831a5e141b574fc9253453f716</BaseURL>
+        <SegmentList duration="262952" timescale="44100">
+          <Initialization range="0-1283"/>
+          <SegmentURL mediaRange="1284-150731"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/test_manifest_rewrite.py
+++ b/tests/test_manifest_rewrite.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+""" Tests for Manifest rewrite """
+
+# pylint: disable=invalid-name,missing-docstring
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+import unittest
+
+from resources.lib.modules.proxy import Proxy
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TestManifestRewrite(unittest.TestCase):
+    """ Tests for Manifest rewrite """
+
+    def test_rewrite(self):
+        self.maxDiff = None
+        tests = [
+            ('manifest_01_input.xml', 'manifest_01_output.xml'),  # Uses SegmentTemplates
+            ('manifest_02_input.xml', 'manifest_02_output.xml'),  # Uses SegmentLists
+            ('manifest_03_input.xml', 'manifest_03_output.xml'),  # Uses a combination of SegmentTemplates and SegmentLists
+        ]
+
+        for test_input, test_output in tests:
+            with open('tests/manifest_rewrite/' + test_input, 'r') as fdesc:
+                manifest_input = fdesc.read()
+
+            with open('tests/manifest_rewrite/' + test_output, 'r') as fdesc:
+                manifest_output = fdesc.read()
+
+            manifest_modified = Proxy.modify_manifest(manifest_input)
+            self.assertEqual(manifest_modified, manifest_output)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is a workaround for the Inputstream Adaptive issue described in https://github.com/add-ons/plugin.video.vtm.go/issues/241. Basically, we start a HTTP proxy and intercept the request for the Manifest, and modify it before passing it to IA.

When an updated Inputstream Adaptive is generally available, we can remove this workaround.

* Removes the BaseURL from the AdaptationSets with `SegmentTemplate`. The `SegmentList` won't be modified.
* This is controllable with an option in the Expert setting category. It is enabled by default for now.
* Added tests for these specific rewrites.

Fixes #22 