### PR TITLE
Display an error when a captcha should be entered

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -157,6 +157,10 @@ msgctxt "#30703"
 msgid "Your account has no profiles defined. Please login on www.streamz.be and create a profile."
 msgstr ""
 
+msgctxt "#30704"
+msgid "You need to complete a captcha before you can continue. Please login on www.streamz.be with a web browser and try again."
+msgstr ""
+
 msgctxt "#30708"
 msgid "Please restart Kodi."
 msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -158,6 +158,10 @@ msgctxt "#30703"
 msgid "Your account has no profiles defined. Please login on www.streamz.be and create a profile."
 msgstr "Uw account heeft geen profielen. Gelieve in te loggen op www.streamz.be en een profiel aan te maken."
 
+msgctxt "#30704"
+msgid "You need to complete a captcha before you can continue. Please login on www.streamz.be with a web browser and try again."
+msgstr "U moet een captcha vervolledigen voordat u kan verdergaan. Gelieve in te loggen op www.streamz.be met een webbrowser en probeer opnieuw."
+
 msgctxt "#30708"
 msgid "Please restart Kodi."
 msgstr "Gelieve Kodi te herstarten."

--- a/resources/lib/modules/authentication.py
+++ b/resources/lib/modules/authentication.py
@@ -11,7 +11,8 @@ from resources.lib import kodiutils
 from resources.lib.kodiutils import TitleItem
 from resources.lib.streamz.api import Api
 from resources.lib.streamz.auth import Auth
-from resources.lib.streamz.exceptions import InvalidLoginException, LoginErrorException, NoStreamzSubscriptionException, NoTelenetSubscriptionException
+from resources.lib.streamz.exceptions import (CaptchaRequiredException, InvalidLoginException, LoginErrorException, NoStreamzSubscriptionException,
+                                              NoTelenetSubscriptionException)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,7 +34,6 @@ class Authentication:
         """ Verify if the user has credentials and if they are valid. """
         retry = False
         while True:
-
             # Check if the user has credentials
             if retry or not kodiutils.get_setting('username') or not kodiutils.get_setting('password'):
 
@@ -64,6 +64,10 @@ class Authentication:
             except NoTelenetSubscriptionException:
                 kodiutils.ok_dialog(message=kodiutils.localize(30202))  # Your Telenet account has no valid subscription!
                 retry = True
+
+            except CaptchaRequiredException:
+                kodiutils.ok_dialog(message=kodiutils.localize(30704))  # You need to complete a captcha before you can continue...
+                retry = False
 
             except LoginErrorException as exc:
                 kodiutils.ok_dialog(message=kodiutils.localize(30702, code=exc.code))  # Unknown error while logging in: {code}

--- a/resources/lib/modules/catalog.py
+++ b/resources/lib/modules/catalog.py
@@ -8,7 +8,7 @@ import logging
 from resources.lib import kodiutils
 from resources.lib.kodiutils import TitleItem
 from resources.lib.modules.menu import Menu
-from resources.lib.streamz import Category, STOREFRONT_SERIES, STOREFRONT_MOVIES
+from resources.lib.streamz import STOREFRONT_MOVIES, STOREFRONT_SERIES, Category
 from resources.lib.streamz.api import CACHE_PREVENT, Api
 from resources.lib.streamz.auth import Auth
 from resources.lib.streamz.exceptions import UnavailableException

--- a/resources/lib/streamz/auth.py
+++ b/resources/lib/streamz/auth.py
@@ -10,8 +10,8 @@ import re
 from hashlib import md5
 
 from resources.lib.streamz import API_ENDPOINT, Profile, util
-from resources.lib.streamz.exceptions import (InvalidLoginException, LoginErrorException, NoLoginException, NoStreamzSubscriptionException,
-                                              NoTelenetSubscriptionException)
+from resources.lib.streamz.exceptions import (CaptchaRequiredException, InvalidLoginException, LoginErrorException, NoLoginException,
+                                              NoStreamzSubscriptionException, NoTelenetSubscriptionException)
 
 try:  # Python 3
     from urllib.parse import parse_qs, urlsplit
@@ -227,6 +227,9 @@ class Auth:
 
             if 'Je gebruikersnaam en/of wachtwoord zijn verkeerd' in response.text:
                 raise InvalidLoginException
+
+            if 'Vul de beveiligingscontrole in om verder te gaan' in response.text:
+                raise CaptchaRequiredException
 
         else:
             raise Exception('Unsupported login method: %s' % self._loginprovider)

--- a/resources/lib/streamz/exceptions.py
+++ b/resources/lib/streamz/exceptions.py
@@ -16,6 +16,10 @@ class InvalidLoginException(Exception):
     """ Is thrown when the credentials are invalid. """
 
 
+class CaptchaRequiredException(Exception):
+    """ Is thrown when a captcha should be filled in. """
+
+
 class NoStreamzSubscriptionException(Exception):
     """ Is thrown when you don't have an subscription with Streamz. """
 


### PR DESCRIPTION
The telenet login displays a captcha, probably when trying to many times with an incorrect password. We handle this and display an appropriate message.

Fixes #25 