### PR TITLE
Add support for media protected with drmtoday

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -153,10 +153,6 @@ msgctxt "#30713"
 msgid "You have reached the maximum amount of concurrent streams. Please stop streaming on another device to start watching here."
 msgstr ""
 
-msgctxt "#30718"
-msgid "The Manifest proxy is not running. Please restart Kodi."
-msgstr ""
-
 # SETTINGS
 msgctxt "#30820"
 msgid "Interface"
@@ -236,10 +232,6 @@ msgstr ""
 
 msgctxt "#30887"
 msgid "InputStream Helper settings…"
-msgstr ""
-
-msgctxt "#30888"
-msgid "Modify the MPEG DASH Manifest to workaround an InputStream Adaptive bug"
 msgstr ""
 
 msgctxt "#30889"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -155,10 +155,6 @@ msgctxt "#30713"
 msgid "You have reached the maximum amount of concurrent streams. Please stop streaming on another device to start watching here."
 msgstr "U heeft het maximum aantal gelijktijdige streams bereikt. Gelieve te stoppen met streamen op een ander apparaat om hier te beginnen kijken."
 
-msgctxt "#30718"
-msgid "The Manifest proxy is not running. Please restart Kodi."
-msgstr "De Manifest-proxy is niet gestart. Gelieve Kodi te herstarten."
-
 # SETTINGS
 msgctxt "#30820"
 msgid "Interface"
@@ -239,10 +235,6 @@ msgstr "InputStream Adaptive configuratie…"
 msgctxt "#30887"
 msgid "InputStream Helper settings…"
 msgstr "InputStream Helper configuratie…"
-
-msgctxt "#30888"
-msgid "Modify the MPEG DASH Manifest to workaround an InputStream Adaptive bug"
-msgstr "Pas de MPEG DASH Manifest aan om rond een bug in InputStream Adaptive te werken"
 
 msgctxt "#30889"
 msgid "Logging"

--- a/resources/lib/modules/player.py
+++ b/resources/lib/modules/player.py
@@ -106,10 +106,8 @@ class Player:
             # This allows to play some programs that don't have metadata (yet).
             pass
 
-        license_key = self._stream.create_license_key(resolved_stream.license_url)
-
         # Play this item
-        kodiutils.play(resolved_stream.url, license_key, resolved_stream.title, {}, info_dict, prop_dict, stream_dict, subtitles=resolved_stream.subtitles)
+        kodiutils.play(resolved_stream.url, resolved_stream.license_key, resolved_stream.title, {}, info_dict, prop_dict, stream_dict, subtitles=resolved_stream.subtitles)
 
         # Wait for playback to start
         kodi_player = KodiPlayer()

--- a/resources/lib/streamz/__init__.py
+++ b/resources/lib/streamz/__init__.py
@@ -219,14 +219,14 @@ class Episode:
 class ResolvedStream:
     """ Defines a stream that we can play"""
 
-    def __init__(self, program=None, program_id=None, title=None, duration=None, url=None, license_url=None, subtitles=None, cookies=None):
+    def __init__(self, program=None, program_id=None, title=None, duration=None, url=None, license_key=None, subtitles=None, cookies=None):
         """
         :type program: str
         :type program_id: str
         :type title: str
         :type duration: str
         :type url: str
-        :type license_url: str
+        :type license_key: str
         :type subtitles: list[str]
         :type cookies: dict
         """
@@ -235,7 +235,7 @@ class ResolvedStream:
         self.title = title
         self.duration = duration
         self.url = url
-        self.license_url = license_url
+        self.license_key = license_key
         self.subtitles = subtitles
         self.cookies = cookies
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -23,8 +23,6 @@
         <setting label="30883" type="action" id="ishelper_info" action="RunScript(script.module.inputstreamhelper, info)"/>
         <setting label="30885" type="action" id="adaptive_settings" option="close" action="Addon.OpenSettings(inputstream.adaptive)" visible="System.HasAddon(inputstream.adaptive) + [String.StartsWith(System.BuildVersion,18) | String.StartsWith(System.BuildVersion,19)]"/>
         <setting label="30887" type="action" id="ishelper_settings" option="close" action="Addon.OpenSettings(script.module.inputstreamhelper)"/>
-        <setting label="30888" type="bool" id="manifest_proxy" default="true"/>
-        <setting id="manifest_proxy_port" visible="false"/>
         <setting label="30889" type="lsep"/> <!-- Logging -->
         <setting label="30891" type="bool" id="debug_logging" default="false"/>
         <setting label="30892" type="action" action="InstallAddon(script.kodi.loguploader)" option="close" visible="!System.HasAddon(script.kodi.loguploader)"/> <!-- Install Kodi Logfile Uploader -->


### PR DESCRIPTION
Some content is protected with drmtoday instead of anvato. For drmtoday, we need to pass a few extra headers.